### PR TITLE
fix construct_buffer() for SpatialPoints, if statement in wrong location

### DIFF
--- a/R/construct_buffer.R
+++ b/R/construct_buffer.R
@@ -26,69 +26,66 @@ construct_buffer <- function(points, shape, size) {
         points <- matrix(sp::coordinates(points), ncol = 2)
     }
 
-    else if(class(points) == "matrix") {
+    else if(class(points) != "matrix") {
+        stop(paste0("Not able to work with class of points: " , class(points)))
+    }
 
-        if(shape == "circle") {
+    if(shape == "circle") {
 
-            circle_points_x <- sin(seq(0, 2 * pi, length.out = 100)) * size
-            circle_points_y <- cos(seq(0, 2 * pi, length.out = 100)) * size
+        circle_points_x <- sin(seq(0, 2 * pi, length.out = 100)) * size
+        circle_points_y <- cos(seq(0, 2 * pi, length.out = 100)) * size
 
-            x_circle <- outer(circle_points_x,  points[, 1], `+`)
-            y_circle <- outer(circle_points_y,  points[, 2], `+`)
+        x_circle <- outer(circle_points_x,  points[, 1], `+`)
+        y_circle <- outer(circle_points_y,  points[, 2], `+`)
 
-            sample_plots_coords <- cbind(matrix(x_circle, ncol = 1),
-                                         matrix(y_circle, ncol = 1),
-                                         rep(1:nrow(points), each = 100))
+        sample_plots_coords <- cbind(matrix(x_circle, ncol = 1),
+                                     matrix(y_circle, ncol = 1),
+                                     rep(1:nrow(points), each = 100))
 
-            sample_plots_coords_split <- split(sample_plots_coords[, -3], sample_plots_coords[, 3])
+        sample_plots_coords_split <- split(sample_plots_coords[, -3], sample_plots_coords[, 3])
 
-            sample_plots <- purrr::map(sample_plots_coords_split, function(x) {
-                sp::Polygon(cbind(x[1:100], x[101:200]))
-            })
+        sample_plots <- purrr::map(sample_plots_coords_split, function(x) {
+            sp::Polygon(cbind(x[1:100], x[101:200]))
+        })
 
-            sample_plots <- sp::SpatialPolygons(purrr::map(seq_along(sample_plots), function(y) {
-                sp::Polygons(list(sample_plots[[y]]), ID = y)
-            }))
-        }
+        sample_plots <- sp::SpatialPolygons(purrr::map(seq_along(sample_plots), function(y) {
+            sp::Polygons(list(sample_plots[[y]]), ID = y)
+        }))
+    }
 
-        else if (shape == "square") {
+    else if (shape == "square") {
 
-            sample_plots_coords <- cbind(
-                matrix(
-                    c(points[, 1] - size / 2,
-                      points[, 1] - size / 2,
-                      points[, 1] + size / 2,
-                      points[, 1] + size / 2),
-                    ncol = 1),
+        sample_plots_coords <- cbind(
+            matrix(
+                c(points[, 1] - size / 2,
+                  points[, 1] - size / 2,
+                  points[, 1] + size / 2,
+                  points[, 1] + size / 2),
+                ncol = 1),
 
-                matrix(
-                    c(points[, 2] - size / 2,
-                      points[, 2] + size / 2,
-                      points[, 2] + size / 2,
-                      points[, 2] - size / 2),
-                    ncol = 1),
-                rep(1:nrow(points), times = 4)
-            )
+            matrix(
+                c(points[, 2] - size / 2,
+                  points[, 2] + size / 2,
+                  points[, 2] + size / 2,
+                  points[, 2] - size / 2),
+                ncol = 1),
+            rep(1:nrow(points), times = 4)
+        )
 
-            sample_plots_coords_split <- split(sample_plots_coords[, -3], sample_plots_coords[, 3])
+        sample_plots_coords_split <- split(sample_plots_coords[, -3], sample_plots_coords[, 3])
 
-            sample_plots <- purrr::map(sample_plots_coords_split, function(x) {
-                sp::Polygon(cbind(x[1:4], x[5:8]))
-            })
+        sample_plots <- purrr::map(sample_plots_coords_split, function(x) {
+            sp::Polygon(cbind(x[1:4], x[5:8]))
+        })
 
-            sample_plots <- sp::SpatialPolygons(purrr::map(seq_along(sample_plots), function(y) {
-                sp::Polygons(list(sample_plots[[y]]), ID = y)
-            }))
-        }
-
-        else{
-            stop(paste0("Shape option ", shape, " unkown"), call. = FALSE)
-        }
-
-        return(sample_plots)
+        sample_plots <- sp::SpatialPolygons(purrr::map(seq_along(sample_plots), function(y) {
+            sp::Polygons(list(sample_plots[[y]]), ID = y)
+        }))
     }
 
     else{
-        stop(paste0("Not able to work with class of points: " , class(points)))
+        stop(paste0("Shape option ", shape, " unkown"), call. = FALSE)
     }
+
+    return(sample_plots)
 }


### PR DESCRIPTION
`sample_metrics()` wasn't working for `SpatialPoints` objects, traced error to `construct_buffer()`, which was returning a matrix rather than polygons for `SpatialPoints` objects. Fixed a mixed up if statement, should work now.