### PR TITLE
Matrix conversion

### DIFF
--- a/R/calculate_lsm.R
+++ b/R/calculate_lsm.R
@@ -105,10 +105,12 @@ calculate_lsm.RasterLayer <- function(landscape,
                      verbose = verbose,
                      progress = progress)
 
-    result <- dplyr::bind_rows(result, .id = "layer2")
+    result <- dplyr::bind_rows(result, .id = "layer")
 
-    dplyr::select(dplyr::mutate(result, layer = as.integer(layer2)),
-                  -layer2)
+    result <- dplyr::arrange(result,
+                             layer, level, metric, class, id)
+
+    return(result)
 }
 
 #' @name calculate_lsm
@@ -150,10 +152,12 @@ calculate_lsm.RasterStack <- function(landscape,
                      verbose = verbose,
                      progress = progress)
 
-    result <- dplyr::bind_rows(result, .id = "layer2")
+    result <- dplyr::bind_rows(result, .id = "layer")
 
-    dplyr::select(dplyr::mutate(result, layer = as.integer(layer2)),
-                  -layer2)
+    result <- dplyr::arrange(result,
+                             layer, level, metric, class, id)
+
+    return(result)
 }
 
 #' @name calculate_lsm
@@ -195,10 +199,12 @@ calculate_lsm.RasterBrick <- function(landscape,
                      verbose = verbose,
                      progress = progress)
 
-    result <- dplyr::bind_rows(result, .id = "layer2")
+    result <- dplyr::bind_rows(result, .id = "layer")
 
-    dplyr::select(dplyr::mutate(result, layer = as.integer(layer2)),
-                  -layer2)
+    result <- dplyr::arrange(result,
+                             layer, level, metric, class, id)
+
+    return(result)
 }
 
 #' @name calculate_lsm
@@ -242,10 +248,12 @@ calculate_lsm.stars <- function(landscape,
                      verbose = verbose,
                      progress = progress)
 
-    result <- dplyr::bind_rows(result, .id = "layer2")
+    result <- dplyr::bind_rows(result, .id = "layer")
 
-    dplyr::select(dplyr::mutate(result, layer = as.integer(layer2)),
-                  -layer2)
+    result <- dplyr::arrange(result,
+                             layer, level, metric, class, id)
+
+    return(result)
 }
 
 
@@ -288,10 +296,12 @@ calculate_lsm.list <- function(landscape,
                      verbose = verbose,
                      progress = progress)
 
-    result <- dplyr::bind_rows(result, .id = "layer2")
+    result <- dplyr::bind_rows(result, .id = "layer")
 
-    dplyr::select(dplyr::mutate(result, layer = as.integer(layer2)),
-                  -layer2)
+    result <- dplyr::arrange(result,
+                             layer, level, metric, class, id)
+
+    return(result)
 }
 
 calculate_lsm_internal <- function(landscape,
@@ -312,6 +322,7 @@ calculate_lsm_internal <- function(landscape,
                                    verbose,
                                    progress) {
 
+    # get name of metrics
     metrics <- landscapemetrics::list_lsm(level = level,
                                           metric = metric,
                                           name = name,
@@ -320,16 +331,34 @@ calculate_lsm_internal <- function(landscape,
                                           simplify = TRUE,
                                           verbose = verbose)
 
-    result_all_list <- lapply(seq_along(metrics), FUN = function(current_metric) {
+    # use internal functions for calculation
+    metrics_calc <- paste0(metrics, "_calc")
 
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # keep raster
+    landscape_raster <- landscape
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    result_all_list <- lapply(seq_along(metrics_calc), FUN = function(current_metric) {
+
+        # print progess using the non-internal name
         if(isTRUE(progress)){
             cat("\r> Progress: ", current_metric, "/",
-                length(metrics), "- Current metric: ",
-                metrics[[current_metric]], " ")
+                length(metrics_calc), "- Current metric: ",
+                metrics_calc[[current_metric]], " ")
         }
 
-        foo <- match.fun(metrics[[current_metric]])
+        # match function name
+        foo <- match.fun(metrics_calc[[current_metric]])
+
+        # get argument
         arguments <- names(formals(foo))
+
+        # run function
         do.call(what = foo,
                 args = mget(arguments, envir = parent.env(environment())))
     })
@@ -341,9 +370,6 @@ calculate_lsm_internal <- function(landscape,
                                    y = landscapemetrics::lsm_abbreviations_names,
                                    by = c("metric", "level"))
     }
-
-    result <- dplyr::arrange(result,
-                             layer, level, metric, class, id)
 
     return(result)
 }

--- a/R/calculate_lsm.R
+++ b/R/calculate_lsm.R
@@ -334,11 +334,13 @@ calculate_lsm_internal <- function(landscape,
     # use internal functions for calculation
     metrics_calc <- paste0(metrics, "_calc")
 
-    # get resolution
-    resolution <- raster::res(landscape)
+    # how many metrics need to be calculated?
+    number_metrics <- length(metrics_calc)
 
-    # keep raster
-    landscape_raster <- landscape
+    # properties of original raster
+    extent <- raster::extent(landscape)
+    resolution <- raster::res(landscape)
+    crs <- raster::crs(landscape)
 
     # convert to matrix
     landscape <- raster::as.matrix(landscape)
@@ -348,12 +350,13 @@ calculate_lsm_internal <- function(landscape,
         # print progess using the non-internal name
         if(isTRUE(progress)){
             cat("\r> Progress: ", current_metric, "/",
-                length(metrics_calc), "- Current metric: ",
-                metrics_calc[[current_metric]], " ")
+                number_metrics, "- Current metric: ",
+                metrics[[current_metric]], " ")
         }
 
         # match function name
-        foo <- match.fun(metrics_calc[[current_metric]])
+        # foo <- match.fun(metrics_calc[[current_metric]])
+        foo <- get(metrics_calc[[current_metric]], mode = "function")
 
         # get argument
         arguments <- names(formals(foo))

--- a/R/calculate_lsm.R
+++ b/R/calculate_lsm.R
@@ -355,7 +355,6 @@ calculate_lsm_internal <- function(landscape,
         }
 
         # match function name
-        # foo <- match.fun(metrics_calc[[current_metric]])
         foo <- get(metrics_calc[[current_metric]], mode = "function")
 
         # get argument

--- a/R/get_circumscribingcircle.R
+++ b/R/get_circumscribingcircle.R
@@ -1,29 +1,23 @@
 #' get_circumscribingcircle
 #'
-#' @description Calculates the diameter of the smallest circumscribing circle around patches in a landscape.
+#' @description Diameter of the circumscribing circle around patches
 #'
-#' @param landscape RasterLayer or matrix (with x,y,id columns)
+#' @param landscape RasterLayer or matrix (with x, y, id columns)
 #' @param resolution_x Resolution of the landscape (only needed if matrix as input is used)
 #' @param resolution_y Resolution of the landscape (only needed if matrix as input is used)
-
 #'
 #' @details
-#' Fast and memory safe Rcpp implementation for calculating maximum euclidean distances between
-#' cells of the same class in a raster or matrix. Uses the edge boundary of cells,
-#' not the cell center. Using the edge boundary and the maximum distance between
-#' the 4 cell corners around each cell center of the patch derives in the diameter of
-#' the smallest circumscribing circle around a patch.
-#'
-#' If one uses this functions with a matrix the resolution of the underlying data must be provided.#'
-#'
-#' @references
-#' Based on RCpp code of Florian Privé \email{florian.prive.21@gmail.com}
+#' The diameter of the smallest circumscribing circle around a patch in the landscape
+#' is based on the maximum distance between the corners of each cell. This ensures that all
+#' cells of the patch are included in the patch. All patches need an unique
+#' ID (see \code{\link{get_patches}}). If one uses this functions with a matrix the
+#' resolution of the underlying data must be provided.
 #'
 #' @examples
 #' # get patches for class 1 from testdata as raster
 #' class_1 <- get_patches(landscape, class = 1)[[1]]
 #'
-#' # calculate the max distance between cell edges of each class
+#' # calculate the minimum circumscribing circle of each patch in class 1
 #' get_circumscribingcircle(class_1)
 #'
 #' # do the same with a 3 column matrix (x, y, id)
@@ -63,7 +57,7 @@ get_circumscribingcircle.matrix <- function(landscape,
                                             resolution_x = NULL,
                                             resolution_y = NULL) {
 
-    if ( ncol(landscape) != 3){
+    if (ncol(landscape) != 3){
         stop("Coordinate matrix must have 3 (x, y, id) columns.", call. = TRUE)
     }
 

--- a/R/get_nearestneighbour.R
+++ b/R/get_nearestneighbour.R
@@ -1,12 +1,16 @@
 #' get_nearestneighbour
 #'
-#' @description Calculates the minimal euclidean distance between classes for a raster/matrix.
+#' @description Euclidean distance to nearest neighbour
 #'
 #' @param landscape RasterLayer or matrix (with x,y,id columns)
 #'
 #' @details
-#' Fast and memory safe Rcpp implementation for calculating minimal euclidean distances between
-#' classes in a raster or matrix.
+#' Fast and memory safe Rcpp implementation for calculating the minimum Euclidean
+#' distances to the nearest patch of the same class in a raster or matrix. All patches need an unique
+#' ID (see \code{\link{get_patches}}).
+#'
+#' @references
+#' Based on RCpp code of Florian Privé \email{florian.prive.21@gmail.com}
 #'
 #' @examples
 #' # get patches for class 1 from testdata as raster
@@ -15,7 +19,7 @@
 #' # calculate the distance between patches
 #' get_nearestneighbour(class_1)
 #'
-#' # do the same with a 3 column matrix (x,y,id)
+#' # do the same with a 3 column matrix (x, y, id)
 #' class_1_matrix <- raster::rasterToPoints(class_1)
 #' get_nearestneighbour(class_1_matrix)
 #'

--- a/R/list_lsm.R
+++ b/R/list_lsm.R
@@ -99,7 +99,7 @@ list_lsm <- function(level = NULL,
     result <- dplyr::select(result, -metric_new)
 
     if(simplify) {
-        result <- dplyr::pull(result, function_name)
+        result <- result$function_name
     }
 
     return(result)

--- a/R/lsm_c_ai.R
+++ b/R/lsm_c_ai.R
@@ -102,7 +102,9 @@ lsm_c_ai.list <- function(landscape) {
 lsm_c_ai_calc <- function(landscape) {
 
     # convert to raster to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get coocurrence matrix of like_adjacencies
     like_adjacencies <- rcpp_get_coocurrence_matrix_diag(landscape,

--- a/R/lsm_c_ai.R
+++ b/R/lsm_c_ai.R
@@ -129,7 +129,7 @@ lsm_c_ai_calc <- function(landscape) {
                              )
 
     # get only max_adj as vector
-    max_adj <- dplyr::pull(max_adj, max_adj)
+    max_adj <- max_adj$max_adj
 
     # calculate aggregation index
     ai <- (like_adjacencies / max_adj) * 100

--- a/R/lsm_c_area_cv.R
+++ b/R/lsm_c_area_cv.R
@@ -108,13 +108,7 @@ lsm_c_area_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_area_cv_calc <- function(landscape, directions){
-
-    # resolution of raster
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_area_cv_calc <- function(landscape, directions, resolution = NULL){
 
     # get area of patches
     area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_area_cv.R
+++ b/R/lsm_c_area_cv.R
@@ -110,8 +110,18 @@ lsm_c_area_cv.list <- function(landscape, directions = 8) {
 
 lsm_c_area_cv_calc <- function(landscape, directions){
 
-    area <- lsm_p_area_calc(landscape, directions = directions)
+    # resolution of raster
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get area of patches
+    area <- lsm_p_area_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
+
+    # calculate cv
     area_cv <- dplyr::summarise(dplyr::group_by(area, class),
                                 value = raster::cv(value))
 

--- a/R/lsm_c_area_mn.R
+++ b/R/lsm_c_area_mn.R
@@ -111,8 +111,18 @@ lsm_c_area_mn.list <- function(landscape, directions = 8) {
 
 lsm_c_area_mn_calc <- function(landscape, directions){
 
-    area <- lsm_p_area_calc(landscape, directions = directions)
+    # resolution of raster
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get area of patches
+    area <- lsm_p_area_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
+
+    # calculate mean
     area_mean <- dplyr::summarise(dplyr::group_by(area, class),
                                   value = mean(value))
 

--- a/R/lsm_c_area_mn.R
+++ b/R/lsm_c_area_mn.R
@@ -109,13 +109,7 @@ lsm_c_area_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_area_mn_calc <- function(landscape, directions){
-
-    # resolution of raster
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_area_mn_calc <- function(landscape, directions, resolution = NULL){
 
     # get area of patches
     area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_area_sd.R
+++ b/R/lsm_c_area_sd.R
@@ -108,13 +108,7 @@ lsm_c_area_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_area_sd_calc <- function(landscape, directions){
-
-    # resolution of raster
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_area_sd_calc <- function(landscape, directions, resolution = NULL){
 
     # get area of patches
     area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_area_sd.R
+++ b/R/lsm_c_area_sd.R
@@ -110,8 +110,18 @@ lsm_c_area_sd.list <- function(landscape, directions = 8) {
 
 lsm_c_area_sd_calc <- function(landscape, directions){
 
-    area <- lsm_p_area_calc(landscape, directions = directions)
+    # resolution of raster
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get area of patches
+    area <- lsm_p_area_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
+
+    # calculate sd
     area_sd <- dplyr::summarise(dplyr::group_by(area, class),
                                 value = stats::sd(value))
 

--- a/R/lsm_c_circle_cv.R
+++ b/R/lsm_c_circle_cv.R
@@ -107,7 +107,6 @@ lsm_c_circle_cv.stars <- function(landscape, directions = 8) {
 #' @name lsm_c_circle_cv
 #' @export
 lsm_c_circle_cv.list <- function(landscape, directions = 8) {
-
     result <- lapply(X = landscape,
                      FUN = lsm_c_circle_cv_calc,
                      directions = directions)
@@ -116,9 +115,12 @@ lsm_c_circle_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_circle_cv_calc <- function(landscape, directions) {
+lsm_c_circle_cv_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    circle <- lsm_p_circle_calc(landscape, directions = directions)
+    circle <- lsm_p_circle_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     circle_cv <-  dplyr::summarize(dplyr::group_by(circle, class),
                                    value = raster::cv(value))

--- a/R/lsm_c_circle_mn.R
+++ b/R/lsm_c_circle_mn.R
@@ -113,9 +113,12 @@ lsm_c_circle_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_circle_mn_calc <- function(landscape, directions) {
+lsm_c_circle_mn_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    circle <- lsm_p_circle_calc(landscape, directions = directions)
+    circle <- lsm_p_circle_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     circle_mn <-  dplyr::summarize(dplyr::group_by(circle, class),
                                    value = mean(value))

--- a/R/lsm_c_circle_sd.R
+++ b/R/lsm_c_circle_sd.R
@@ -113,9 +113,12 @@ lsm_c_circle_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_circle_sd_calc <- function(landscape, directions) {
+lsm_c_circle_sd_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    circle <- lsm_p_circle_calc(landscape, directions = directions)
+    circle <- lsm_p_circle_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     circle_sd <-  dplyr::summarize(dplyr::group_by(circle, class),
                                    value = stats::sd(value))

--- a/R/lsm_c_clumpy.R
+++ b/R/lsm_c_clumpy.R
@@ -121,18 +121,17 @@ lsm_c_clumpy_calc <- function(landscape, resolution = NULL){
                                   value = cells_class)
 
     # calculate minimum perimeter
-    min_e <- dplyr::pull(dplyr::mutate(cells_class,
+    min_e <- dplyr::mutate(cells_class,
                                        n = trunc(sqrt(value)),
                                        m = value - n ^ 2,
                                        min_e = dplyr::case_when(
                                            m == 0 ~ n * 4,
                                            n ^ 2 < value & value <= n * (1 + n) ~ 4 * n + 2,
-                                           value > n * (1 + n) ~ 4 * n + 4
-                                           )
-                                       ), min_e)
+                                           value > n * (1 + n) ~ 4 * n + 4)
+                           )
 
     # calculate g_i
-    g_i <- like_adjacencies / (colSums(other_adjacencies) - min_e)
+    g_i <- like_adjacencies / (colSums(other_adjacencies) - min_e$min_e)
 
     # proportional class area - direction has no influence on PLAND
     prop_class <- lsm_c_pland_calc(landscape,

--- a/R/lsm_c_clumpy.R
+++ b/R/lsm_c_clumpy.R
@@ -98,7 +98,7 @@ lsm_c_clumpy.list <- function(landscape) {
                   layer = as.integer(layer))
 }
 
-lsm_c_clumpy_calc <- function(landscape){
+lsm_c_clumpy_calc <- function(landscape, resolution = NULL){
 
     # pad landscape to also include adjacencies at landscape boundary
     landscape_padded <- pad_raster(landscape)
@@ -134,8 +134,12 @@ lsm_c_clumpy_calc <- function(landscape){
     # calculate g_i
     g_i <- like_adjacencies / (colSums(other_adjacencies) - min_e)
 
-    # proportional class area
-    prop_class <- lsm_c_pland(landscape)$value / 100
+    # proportional class area - direction has no influence on PLAND
+    prop_class <- lsm_c_pland_calc(landscape,
+                                   directions = 8,
+                                   resolution = resolution)
+
+    prop_class <- prop_class$value / 100
 
     # calculate clumpy
     clumpy <- sapply(seq_along(g_i), function(row_ind) {

--- a/R/lsm_c_cohesion.R
+++ b/R/lsm_c_cohesion.R
@@ -128,7 +128,7 @@ lsm_c_cohesion_calc <- function(landscape, directions) {
 
     # get number of cells for each patch -> area = n_cells * res / 10000
     ncells_patch <-  dplyr::mutate(patch_area,
-                                   value = value * 10000 / resolution)
+                                   value = value * 10000 / prod(resolution))
 
     # get perim of patch
     perim_patch <- lsm_p_perim_calc(landscape,

--- a/R/lsm_c_cohesion.R
+++ b/R/lsm_c_cohesion.R
@@ -113,18 +113,27 @@ lsm_c_cohesion.list <- function(landscape, directions = 8) {
 lsm_c_cohesion_calc <- function(landscape, directions) {
 
     # get resolution of raster
-    resolution_xy <- prod(raster::res(landscape))
+    resolution <- raster::res(landscape)
 
-    # get number of cells
-    ncells_landscape <- raster::ncell(landscape)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get number of cells (only not NAs)
+    ncells_landscape <- length(landscape[!is.na(landscape)])
+
+    # get patch area
+    patch_area <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # get number of cells for each patch -> area = n_cells * res / 10000
-    ncells_patch <-  dplyr::mutate(lsm_p_area_calc(landscape,
-                                                   directions = directions),
-                                   value = value * 10000 / resolution_xy)
+    ncells_patch <-  dplyr::mutate(patch_area,
+                                   value = value * 10000 / resolution)
 
     # get perim of patch
-    perim_patch <- lsm_p_perim_calc(landscape, directions = directions)
+    perim_patch <- lsm_p_perim_calc(landscape,
+                                    directions = directions,
+                                    resolution = resolution)
 
     # calculate denominator of cohesion
     denominator <- dplyr::mutate(perim_patch, value = value * sqrt(ncells_patch$value))

--- a/R/lsm_c_cohesion.R
+++ b/R/lsm_c_cohesion.R
@@ -110,13 +110,13 @@ lsm_c_cohesion.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_cohesion_calc <- function(landscape, directions) {
+lsm_c_cohesion_calc <- function(landscape, directions, resolution = NULL) {
 
-    # get resolution of raster
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    # convert to raster to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get number of cells (only not NAs)
     ncells_landscape <- length(landscape[!is.na(landscape)])

--- a/R/lsm_c_core_cv.R
+++ b/R/lsm_c_core_cv.R
@@ -121,12 +121,13 @@ lsm_c_core_cv.list <- function(landscape, directions = 8, consider_boundary = FA
                   layer = as.integer(layer))
 }
 
-lsm_c_core_cv_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_core_cv_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL) {
 
     core <- lsm_p_core_calc(landscape,
                             directions = directions,
                             consider_boundary = consider_boundary,
-                            edge_depth = edge_depth)
+                            edge_depth = edge_depth,
+                            resolution = resolution)
 
     core_cv <- dplyr::summarise(dplyr::group_by(core, class),
                                 value = raster::cv(value))

--- a/R/lsm_c_core_mn.R
+++ b/R/lsm_c_core_mn.R
@@ -119,12 +119,13 @@ lsm_c_core_mn.list <- function(landscape, directions = 8, consider_boundary = FA
                   layer = as.integer(layer))
 }
 
-lsm_c_core_mn_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_core_mn_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core <- lsm_p_core_calc(landscape,
                             directions = directions,
                             consider_boundary = consider_boundary,
-                            edge_depth = edge_depth)
+                            edge_depth = edge_depth,
+                            resolution = resolution)
 
     core_mean <- dplyr::summarise(dplyr::group_by(core, class),
                                   value = mean(value))

--- a/R/lsm_c_core_sd.R
+++ b/R/lsm_c_core_sd.R
@@ -121,12 +121,13 @@ lsm_c_core_sd.list <- function(landscape, directions = 8, consider_boundary = FA
                   layer = as.integer(layer))
 }
 
-lsm_c_core_sd_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_core_sd_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core <- lsm_p_core_calc(landscape,
                             directions = directions,
                             consider_boundary = consider_boundary,
-                            edge_depth = edge_depth)
+                            edge_depth = edge_depth,
+                            resolution = resolution)
 
     core_sd <- dplyr::summarise(dplyr::group_by(core, class),
                                 value = stats::sd(value))

--- a/R/lsm_c_cpland.R
+++ b/R/lsm_c_cpland.R
@@ -117,13 +117,14 @@ lsm_c_cpland.list <- function(landscape, directions = 8, consider_boundary = FAL
                   layer = as.integer(layer))
 }
 
-lsm_c_cpland_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_cpland_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
-    # get resolution
-    resolution <- raster::res(landscape)
 
     # conver to matrix
-    landscape <- raster::as.matrix(landscape)
+    if (class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # calculate patch area
     area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_dcad.R
+++ b/R/lsm_c_dcad.R
@@ -121,10 +121,13 @@ lsm_c_dcad.list <- function(landscape, directions = 8, consider_boundary = FALSE
                   layer = as.integer(layer))
 }
 
-lsm_c_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                            extent = NULL, resolution = NULL, crs = NULL){
 
     # get patch area
-    area <- lsm_p_area_calc(landscape, directions = directions)
+    area <- lsm_p_area_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     # summarise to total area
     area <- dplyr::summarise(area, value = sum(value))
@@ -133,7 +136,8 @@ lsm_c_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth
     ndca <- lsm_p_ncore_calc(landscape,
                              directions = directions,
                              consider_boundary = consider_boundary,
-                             edge_depth = edge_depth)
+                             edge_depth = edge_depth,
+                             extent = extent, resolution = resolution, crs = crs)
 
     # summarise for classes
     ndca <- dplyr::summarise(dplyr::group_by(ndca, class), value = sum(value))

--- a/R/lsm_c_dcad.R
+++ b/R/lsm_c_dcad.R
@@ -123,15 +123,24 @@ lsm_c_dcad.list <- function(landscape, directions = 8, consider_boundary = FALSE
 
 lsm_c_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth){
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get patch area
+    area <- lsm_p_area_calc(landscape, directions = directions)
 
-    ndca_class <- lsm_c_ndca_calc(landscape,
-                                  directions = directions,
-                                  consider_boundary = consider_boundary,
-                                  edge_depth = edge_depth)
+    # summarise to total area
+    area <- dplyr::summarise(area, value = sum(value))
 
-    dcad <- dplyr::mutate(ndca_class,
-                          value = (value / area_landscape$value) * 100)
+    # get number of core area
+    ndca <- lsm_p_ncore_calc(landscape,
+                             directions = directions,
+                             consider_boundary = consider_boundary,
+                             edge_depth = edge_depth)
+
+    # summarise for classes
+    ndca <- dplyr::summarise(dplyr::group_by(ndca, class), value = sum(value))
+
+    # calculate relative value
+    dcad <- dplyr::mutate(ndca,
+                          value = (value / area$value) * 100)
 
     tibble::tibble(
         level = "class",

--- a/R/lsm_c_dcore_cv.R
+++ b/R/lsm_c_dcore_cv.R
@@ -125,12 +125,14 @@ lsm_c_dcore_cv.list <- function(landscape, directions = 8, consider_boundary = F
                   layer = as.integer(layer))
 }
 
-lsm_c_dcore_cv_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_dcore_cv_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore <- lsm_p_ncore_calc(landscape,
                               directions = directions,
                               consider_boundary = consider_boundary,
-                              edge_depth = edge_depth)
+                              edge_depth = edge_depth,
+                              extent = extent, resolution = resolution, crs = crs)
 
     dcore_cv <- dplyr::summarise(dplyr::group_by(dcore, class),
                                  value = raster::cv(value))

--- a/R/lsm_c_dcore_mn.R
+++ b/R/lsm_c_dcore_mn.R
@@ -122,12 +122,14 @@ lsm_c_dcore_mn.list <- function(landscape, directions = 8, consider_boundary = F
                   layer = as.integer(layer))
 }
 
-lsm_c_dcore_mn_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_dcore_mn_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore <- lsm_p_ncore_calc(landscape,
                               directions = directions,
                               consider_boundary = consider_boundary,
-                              edge_depth = edge_depth)
+                              edge_depth = edge_depth,
+                              extent = extent, resolution = resolution, crs = crs)
 
     dcore_mn <- dplyr::summarise(dplyr::group_by(dcore, class),
                                  value = mean(value))

--- a/R/lsm_c_dcore_sd.R
+++ b/R/lsm_c_dcore_sd.R
@@ -127,12 +127,14 @@ lsm_c_dcore_sd.list <- function(landscape, directions = 8, consider_boundary = F
                   layer = as.integer(layer))
 }
 
-lsm_c_dcore_sd_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_dcore_sd_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore <- lsm_p_ncore_calc(landscape,
                               directions = directions,
                               consider_boundary = consider_boundary,
-                              edge_depth = edge_depth)
+                              edge_depth = edge_depth,
+                              extent = extent, resolution = resolution, crs = crs)
 
     dcore_sd <- dplyr::summarise(dplyr::group_by(dcore, class),
                                  value = stats::sd(value))

--- a/R/lsm_c_division.R
+++ b/R/lsm_c_division.R
@@ -109,15 +109,19 @@ lsm_c_division.list <- function(landscape, directions = 8) {
 
 lsm_c_division_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get patch area
+    patch_area <- lsm_p_area_calc(landscape, directions = directions)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # get total area
+    total_area <- dplyr::summarise(patch_area, value = sum(value))
 
-    division <- dplyr::mutate(area_patch,
-                              value = (value / area_landscape$value) ^ 2)
+    # calculate division for each patch
+    division <- dplyr::mutate(patch_area,
+                              value = (value / total_area$value) ^ 2)
 
+    # calculate over division for classes
     division <-  dplyr::mutate(dplyr::summarise(dplyr::group_by(division, class),
-                                 value = sum(value)),
+                                                value = sum(value)),
                                value = 1 - value)
 
     tibble::tibble(

--- a/R/lsm_c_division.R
+++ b/R/lsm_c_division.R
@@ -107,10 +107,12 @@ lsm_c_division.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_division_calc <- function(landscape, directions) {
+lsm_c_division_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
-    patch_area <- lsm_p_area_calc(landscape, directions = directions)
+    patch_area <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # get total area
     total_area <- dplyr::summarise(patch_area, value = sum(value))

--- a/R/lsm_c_ed.R
+++ b/R/lsm_c_ed.R
@@ -126,14 +126,27 @@ lsm_c_ed.list <- function(landscape,
 
 lsm_c_ed_calc <- function(landscape, count_boundary, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape,
-                                    directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get patch area
+    area <- lsm_p_area_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
+
+    # summarise to total area
+    area <- dplyr::summarise(area, value = sum(value))
+
+    # get total edge length
     edge_landscape <- lsm_c_te_calc(landscape,
                                     count_boundary = count_boundary,
-                                    directions = directions)
+                                    directions = directions,
+                                    resolution = resolution)
 
-    ed <- dplyr::mutate(edge_landscape, value = value / area_landscape$value)
+    ed <- dplyr::mutate(edge_landscape, value = value / area$value)
 
     tibble::tibble(
         level = "class",

--- a/R/lsm_c_ed.R
+++ b/R/lsm_c_ed.R
@@ -124,13 +124,13 @@ lsm_c_ed.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_c_ed_calc <- function(landscape, count_boundary, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_c_ed_calc <- function(landscape, count_boundary, directions, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_enn_cv.R
+++ b/R/lsm_c_enn_cv.R
@@ -120,11 +120,13 @@ lsm_c_enn_cv.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_c_enn_cv_calc <- function(landscape, directions, verbose) {
+lsm_c_enn_cv_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn <- lsm_p_enn_calc(landscape,
                           directions = directions,
-                          verbose = verbose)
+                          verbose = verbose,
+                          extent = extent, resolution = resolution, crs = crs)
 
     enn_cv <-  dplyr::summarize(dplyr::group_by(enn, class),
                                 value = raster::cv(value))

--- a/R/lsm_c_enn_mn.R
+++ b/R/lsm_c_enn_mn.R
@@ -121,11 +121,13 @@ lsm_c_enn_mn.list <- function(landscape, directions = 8, verbose = TRUE) {
 }
 
 
-lsm_c_enn_mn_calc <- function(landscape, directions, verbose) {
+lsm_c_enn_mn_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn <- lsm_p_enn_calc(landscape,
                           directions = directions,
-                          verbose = verbose)
+                          verbose = verbose,
+                          extent = extent, resolution = resolution, crs = crs)
 
     enn_mn <-  dplyr::summarize(dplyr::group_by(enn, class),
                                 value = mean(value))

--- a/R/lsm_c_enn_sd.R
+++ b/R/lsm_c_enn_sd.R
@@ -121,11 +121,13 @@ lsm_c_enn_sd.list <- function(landscape, directions = 8, verbose = TRUE) {
 }
 
 
-lsm_c_enn_sd_calc <- function(landscape, directions, verbose) {
+lsm_c_enn_sd_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn <- lsm_p_enn_calc(landscape,
                           directions = directions,
-                          verbose = verbose)
+                          verbose = verbose,
+                          extent = extent, resolution = resolution, crs = crs)
 
     enn_sd <-  dplyr::summarize(dplyr::group_by(enn, class),
                                 value = stats::sd(value))

--- a/R/lsm_c_frac_cv.R
+++ b/R/lsm_c_frac_cv.R
@@ -113,9 +113,11 @@ lsm_c_frac_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_frac_cv_calc <- function(landscape, directions){
+lsm_c_frac_cv_calc <- function(landscape, directions, resolution = NULL){
 
-    frac <- lsm_p_frac_calc(landscape, directions = directions)
+    frac <- lsm_p_frac_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     frac_cv <- dplyr::summarise(dplyr::group_by(frac, class),
                                 value = raster::cv(value))

--- a/R/lsm_c_frac_mn.R
+++ b/R/lsm_c_frac_mn.R
@@ -110,9 +110,11 @@ lsm_c_frac_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_frac_mn_calc <- function(landscape, directions){
+lsm_c_frac_mn_calc <- function(landscape, directions, resolution = NULL){
 
-    frac <- lsm_p_frac_calc(landscape, directions = directions)
+    frac <- lsm_p_frac_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     frac_mean <- dplyr::summarise(dplyr::group_by(frac, class),
                                   value = mean(value))

--- a/R/lsm_c_frac_sd.R
+++ b/R/lsm_c_frac_sd.R
@@ -112,9 +112,11 @@ lsm_c_frac_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_frac_sd_calc <- function(landscape, directions){
+lsm_c_frac_sd_calc <- function(landscape, directions, resolution = NULL){
 
-    frac <- lsm_p_frac_calc(landscape, directions = directions)
+    frac <- lsm_p_frac_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     frac_sd <- dplyr::summarise(dplyr::group_by(frac, class),
                                 value = stats::sd(value))

--- a/R/lsm_c_gyrate_cv.R
+++ b/R/lsm_c_gyrate_cv.R
@@ -114,9 +114,12 @@ lsm_c_gyrate_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_gyrate_cv_calc <- function(landscape, directions) {
+lsm_c_gyrate_cv_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate <- lsm_p_gyrate_calc(landscape, directions = directions)
+    gyrate <- lsm_p_gyrate_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     gyrate_cv <- dplyr::summarize(dplyr::group_by(gyrate, class),
                                   value = raster::cv(value))

--- a/R/lsm_c_gyrate_mn.R
+++ b/R/lsm_c_gyrate_mn.R
@@ -113,9 +113,12 @@ lsm_c_gyrate_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_gyrate_mn_calc <- function(landscape, directions) {
+lsm_c_gyrate_mn_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate <- lsm_p_gyrate_calc(landscape, directions = directions)
+    gyrate <- lsm_p_gyrate_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     gyrate_mn <- dplyr::summarize(dplyr::group_by(gyrate, class),
                                   value = mean(value))

--- a/R/lsm_c_gyrate_sd.R
+++ b/R/lsm_c_gyrate_sd.R
@@ -113,9 +113,12 @@ lsm_c_gyrate_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_gyrate_sd_calc <- function(landscape, directions) {
+lsm_c_gyrate_sd_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate <- lsm_p_gyrate_calc(landscape, directions = directions)
+    gyrate <- lsm_p_gyrate_calc(landscape,
+                                directions = directions,
+                                extent = extent, resolution = resolution, crs = crs)
 
     gyrate_sd <- dplyr::summarize(dplyr::group_by(gyrate, class),
                                   value = stats::sd(value))

--- a/R/lsm_c_iji.R
+++ b/R/lsm_c_iji.R
@@ -109,7 +109,10 @@ lsm_c_iji.list <- function(landscape, verbose = TRUE) {
 
 lsm_c_iji_calc <- function(landscape, verbose) {
 
-    landscape <- raster::as.matrix(landscape)
+    # conver to matrix
+    if (class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     adjacencies <- rcpp_get_coocurrence_matrix(landscape,
                                                as.matrix(4))

--- a/R/lsm_c_lpi.R
+++ b/R/lsm_c_lpi.R
@@ -106,13 +106,17 @@ lsm_c_lpi.list <- function(landscape, directions = 8) {
 
 lsm_c_lpi_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get patch area
+    patch_area <- lsm_p_area_calc(landscape, directions = directions)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # summarise to total area
+    total_area <- dplyr::summarise(patch_area, value = sum(value))
 
-    lpi <- dplyr::mutate(area_patch,
-                         value = value / area_landscape$value * 100)
+    # calculate largest patch index
+    lpi <- dplyr::mutate(patch_area,
+                         value = value / total_area$value * 100)
 
+    # summarise for each class
     lpi <- dplyr::summarise(dplyr::group_by(lpi, class),
                             value = max(value))
 

--- a/R/lsm_c_lpi.R
+++ b/R/lsm_c_lpi.R
@@ -104,10 +104,12 @@ lsm_c_lpi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_lpi_calc <- function(landscape, directions) {
+lsm_c_lpi_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
-    patch_area <- lsm_p_area_calc(landscape, directions = directions)
+    patch_area <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # summarise to total area
     total_area <- dplyr::summarise(patch_area, value = sum(value))

--- a/R/lsm_c_lsi.R
+++ b/R/lsm_c_lsi.R
@@ -107,13 +107,13 @@ lsm_c_lsi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_lsi_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_c_lsi_calc <- function(landscape, directions, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get class edge
     class_edge <- lsm_c_te_calc(landscape,

--- a/R/lsm_c_mesh.R
+++ b/R/lsm_c_mesh.R
@@ -109,13 +109,7 @@ lsm_c_mesh.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_mesh_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_mesh_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     patch_area <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_ndca.R
+++ b/R/lsm_c_ndca.R
@@ -122,13 +122,15 @@ lsm_c_ndca.list <- function(landscape, directions = 8, consider_boundary = FALSE
                   layer = as.integer(layer))
 }
 
-lsm_c_ndca_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_ndca_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                            extent = NULL, resolution = NULL, crs = NULL){
 
     # get number of core areas for each patch
     ndca <- lsm_p_ncore_calc(landscape,
                              directions = directions,
                              consider_boundary = consider_boundary,
-                             edge_depth = edge_depth)
+                             edge_depth = edge_depth,
+                             extent = extent, resolution = resolution, crs = crs)
 
     # summarise for each class
     ndca <- dplyr::summarise(dplyr::group_by(ndca, class), value = sum(value))

--- a/R/lsm_c_ndca.R
+++ b/R/lsm_c_ndca.R
@@ -124,12 +124,14 @@ lsm_c_ndca.list <- function(landscape, directions = 8, consider_boundary = FALSE
 
 lsm_c_ndca_calc <- function(landscape, directions, consider_boundary, edge_depth){
 
-    ndca <- dplyr::summarise(dplyr::group_by(lsm_p_ncore_calc(landscape,
-                                                              directions = directions,
-                                                              consider_boundary = consider_boundary,
-                                                              edge_depth = edge_depth),
-                                             class),
-                             value = sum(value))
+    # get number of core areas for each patch
+    ndca <- lsm_p_ncore_calc(landscape,
+                             directions = directions,
+                             consider_boundary = consider_boundary,
+                             edge_depth = edge_depth)
+
+    # summarise for each class
+    ndca <- dplyr::summarise(dplyr::group_by(ndca, class), value = sum(value))
 
     tibble::tibble(
         level = "class",

--- a/R/lsm_c_nlsi.R
+++ b/R/lsm_c_nlsi.R
@@ -106,13 +106,13 @@ lsm_c_nlsi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_nlsi_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_c_nlsi_calc <- function(landscape, directions, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix"){
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get edge for each class
     class_edge <- lsm_c_te_calc(landscape,

--- a/R/lsm_c_np.R
+++ b/R/lsm_c_np.R
@@ -102,7 +102,9 @@ lsm_c_np.list <- function(landscape, directions = 8) {
 
 lsm_c_np_calc <- function(landscape, directions){
 
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     classes <- get_unique_values(landscape)[[1]]
 

--- a/R/lsm_c_pafrac.R
+++ b/R/lsm_c_pafrac.R
@@ -119,12 +119,24 @@ lsm_c_pafrac.list <- function(landscape, directions = 8, verbose = TRUE) {
 
 lsm_c_pafrac_calc <- function(landscape, directions, verbose){
 
-    area_patch <- dplyr::mutate(lsm_p_area_calc(landscape, directions = directions),
+    # get rsolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get patch area in sqm
+    area_patch <- dplyr::mutate(lsm_p_area_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = value * 10000)
 
+    # get patch perimeter
     perimeter_patch <- lsm_p_perim_calc(landscape,
-                                        directions = directions)
+                                        directions = directions,
+                                        resolution = resolution)
 
+    # get number of patches
     np_class <- lsm_c_np_calc(landscape,
                               directions = directions)
 

--- a/R/lsm_c_pafrac.R
+++ b/R/lsm_c_pafrac.R
@@ -117,13 +117,13 @@ lsm_c_pafrac.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_c_pafrac_calc <- function(landscape, directions, verbose){
-
-    # get rsolution
-    resolution <- raster::res(landscape)
+lsm_c_pafrac_calc <- function(landscape, directions, verbose, resolution = NULL){
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area in sqm
     area_patch <- dplyr::mutate(lsm_p_area_calc(landscape,

--- a/R/lsm_c_para_cv.R
+++ b/R/lsm_c_para_cv.R
@@ -112,7 +112,15 @@ lsm_c_para_cv.list <- function(landscape, directions = 8) {
 
 lsm_c_para_cv_calc <- function(landscape, directions){
 
-    para <- lsm_p_para_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para <- lsm_p_para_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     para_cv <- dplyr::summarise(dplyr::group_by(para, class),
                                 value = raster::cv(value))

--- a/R/lsm_c_para_cv.R
+++ b/R/lsm_c_para_cv.R
@@ -110,13 +110,7 @@ lsm_c_para_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_para_cv_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_para_cv_calc <- function(landscape, directions, resolution = NULL){
 
     para <- lsm_p_para_calc(landscape,
                             directions = directions,

--- a/R/lsm_c_para_mn.R
+++ b/R/lsm_c_para_mn.R
@@ -110,13 +110,7 @@ lsm_c_para_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_para_mn_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_para_mn_calc <- function(landscape, directions, resolution = NULL){
 
     para <- lsm_p_para_calc(landscape,
                             directions = directions,

--- a/R/lsm_c_para_mn.R
+++ b/R/lsm_c_para_mn.R
@@ -112,7 +112,15 @@ lsm_c_para_mn.list <- function(landscape, directions = 8) {
 
 lsm_c_para_mn_calc <- function(landscape, directions){
 
-    para <- lsm_p_para_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para <- lsm_p_para_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     para_mn <- dplyr::summarise(dplyr::group_by(para, class),
                                 value = mean(value))

--- a/R/lsm_c_para_sd.R
+++ b/R/lsm_c_para_sd.R
@@ -112,7 +112,15 @@ lsm_c_para_sd.list <- function(landscape, directions = 8) {
 
 lsm_c_para_sd_calc <- function(landscape, directions){
 
-    para <- lsm_p_para_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para <- lsm_p_para_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     para_sd <- dplyr::summarise(dplyr::group_by(para, class),
                                 value = stats::sd(value))

--- a/R/lsm_c_para_sd.R
+++ b/R/lsm_c_para_sd.R
@@ -110,13 +110,7 @@ lsm_c_para_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_para_sd_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_para_sd_calc <- function(landscape, directions, resolution = NULL){
 
     para <- lsm_p_para_calc(landscape,
                             directions = directions,

--- a/R/lsm_c_pd.R
+++ b/R/lsm_c_pd.R
@@ -105,13 +105,13 @@ lsm_c_pd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_pd_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_c_pd_calc <- function(landscape, directions, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_pd.R
+++ b/R/lsm_c_pd.R
@@ -107,12 +107,26 @@ lsm_c_pd.list <- function(landscape, directions = 8) {
 
 lsm_c_pd_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise to total area
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # get number of patches
     np_class <- lsm_c_np_calc(landscape, directions = directions)
 
+    # calculate relative patch density
     patch_density <- dplyr::mutate(np_class,
-                                   value = (value / area_landscape$value) * 100)
+                                   value = (value / area_total$value) * 100)
 
     tibble::tibble(
         level = "class",

--- a/R/lsm_c_pladj.R
+++ b/R/lsm_c_pladj.R
@@ -96,6 +96,11 @@ lsm_c_pladj.list <- function(landscape) {
 
 lsm_c_pladj_calc <- function(landscape) {
 
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
+
     landscape_padded <- pad_raster(landscape, pad_raster_value = -999,
                                    pad_raster_cells = 1)
 

--- a/R/lsm_c_pland.R
+++ b/R/lsm_c_pland.R
@@ -103,9 +103,11 @@ lsm_c_pland.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_pland_calc <- function(landscape, directions){
+lsm_c_pland_calc <- function(landscape, directions, resolution = NULL){
 
-    pland <- lsm_p_area_calc(landscape, directions = directions)
+    pland <- lsm_p_area_calc(landscape,
+                             directions = directions,
+                             resolution = resolution)
 
     pland <- dplyr::mutate(dplyr::summarise(dplyr::group_by(pland, class),
                                             value = sum(value)),

--- a/R/lsm_c_shape_cv.R
+++ b/R/lsm_c_shape_cv.R
@@ -111,13 +111,7 @@ lsm_c_shape_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_shape_cv_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_shape_cv_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_c_shape_cv.R
+++ b/R/lsm_c_shape_cv.R
@@ -113,8 +113,18 @@ lsm_c_shape_cv.list <- function(landscape, directions = 8) {
 
 lsm_c_shape_cv_calc <- function(landscape, directions){
 
-    shape <- lsm_p_shape_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate cv
     shape_cv <- dplyr::summarise(dplyr::group_by(shape, class),
                                  value = raster::cv(value))
 

--- a/R/lsm_c_shape_mn.R
+++ b/R/lsm_c_shape_mn.R
@@ -111,13 +111,7 @@ lsm_c_shape_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_shape_mn_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_shape_mn_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_c_shape_mn.R
+++ b/R/lsm_c_shape_mn.R
@@ -113,8 +113,18 @@ lsm_c_shape_mn.list <- function(landscape, directions = 8) {
 
 lsm_c_shape_mn_calc <- function(landscape, directions){
 
-    shape <- lsm_p_shape_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate mean
     shape_mn <- dplyr::summarise(dplyr::group_by(shape, class),
                                  value = mean(value))
 

--- a/R/lsm_c_shape_sd.R
+++ b/R/lsm_c_shape_sd.R
@@ -111,13 +111,7 @@ lsm_c_shape_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_shape_sd_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_shape_sd_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_c_shape_sd.R
+++ b/R/lsm_c_shape_sd.R
@@ -113,8 +113,18 @@ lsm_c_shape_sd.list <- function(landscape, directions = 8) {
 
 lsm_c_shape_sd_calc <- function(landscape, directions){
 
-    shape <- lsm_p_shape_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate sd
     shape_sd <- dplyr::summarise(dplyr::group_by(shape, class),
                                  value = stats::sd(value))
 

--- a/R/lsm_c_split.R
+++ b/R/lsm_c_split.R
@@ -107,13 +107,7 @@ lsm_c_split.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_c_split_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_c_split_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_c_split.R
+++ b/R/lsm_c_split.R
@@ -109,15 +109,27 @@ lsm_c_split.list <- function(landscape, directions = 8) {
 
 lsm_c_split_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise to total area
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # calculate split for each patch
     split <- dplyr::mutate(area_patch, value = value ^ 2)
 
+    # summarise for each class
     split <- dplyr::mutate(dplyr::summarise(dplyr::group_by(split, class),
                                             value = sum(value)),
-                           value = (area_landscape$value ^ 2) / value)
+                           value = (area_total$value ^ 2) / value)
 
     tibble::tibble(
         level = "class",

--- a/R/lsm_c_tca.R
+++ b/R/lsm_c_tca.R
@@ -121,12 +121,13 @@ lsm_c_tca.list <- function(landscape, directions = 8, consider_boundary = FALSE,
                   layer = as.integer(layer))
 }
 
-lsm_c_tca_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_c_tca_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core_area <- lsm_p_core_calc(landscape,
                                  directions = directions,
                                  consider_boundary = consider_boundary,
-                                 edge_depth = edge_depth)
+                                 edge_depth = edge_depth,
+                                 resolution = resolution)
 
     core_area <- dplyr::summarise(dplyr::group_by(core_area, class),
                                   value = sum(value))

--- a/R/lsm_c_te.R
+++ b/R/lsm_c_te.R
@@ -117,15 +117,17 @@ lsm_c_te.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_c_te_calc <- function(landscape, count_boundary, directions) {
-
-    # get resolution of raster to convert adjacencies to edge length
-    resolution_xy <- raster::res(landscape)
-    resolution_x <- resolution_xy[[1]]
-    resolution_y <- resolution_xy[[2]]
+lsm_c_te_calc <- function(landscape, count_boundary, directions, resolution = NULL) {
 
     # conver raster to matrix
-    landscape <- raster::as.matrix(landscape)
+    if (class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
+
+    # get resolution in x-y directions
+    resolution_x <- resolution[[1]]
+    resolution_y <- resolution[[2]]
 
     # get class id
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_l_ai.R
+++ b/R/lsm_l_ai.R
@@ -100,27 +100,31 @@ lsm_l_ai.list <- function(landscape) {
                   layer = as.integer(layer))
 }
 
-lsm_l_ai_calc <- function(landscape) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_l_ai_calc <- function(landscape, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get aggregation index for each class
-    ai <- dplyr::pull(lsm_c_ai_calc(landscape), value)
+    ai <- lsm_c_ai_calc(landscape)
 
-    pland <- dplyr::pull(lsm_c_pland_calc(landscape,
-                                          directions = 8,
-                                          resolution = resolution), value) / 100
+    # get proportional class area
+    pland <- lsm_c_pland_calc(landscape,
+                              directions = 8,
+                              resolution = resolution)
+
+    # final AI index
+    result <- sum(ai$value * (pland$value / 100))
 
     tibble::tibble(
         level = "landscape",
         class = as.integer(NA),
         id = as.integer(NA),
         metric = "ai",
-        value = as.double(sum(ai * pland))
+        value = as.double(result)
     )
 }
 

--- a/R/lsm_l_ai.R
+++ b/R/lsm_l_ai.R
@@ -102,19 +102,25 @@ lsm_l_ai.list <- function(landscape) {
 
 lsm_l_ai_calc <- function(landscape) {
 
-    cai <- dplyr::pull(lsm_c_ai(landscape), value)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    prop_class <-  dplyr::pull(lsm_c_pland(landscape), value) / 100
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get aggregation index for each class
+    ai <- dplyr::pull(lsm_c_ai_calc(landscape), value)
+
+    pland <- dplyr::pull(lsm_c_pland_calc(landscape,
+                                          directions = 8,
+                                          resolution = resolution), value) / 100
 
     tibble::tibble(
         level = "landscape",
         class = as.integer(NA),
         id = as.integer(NA),
         metric = "ai",
-        value = as.double(sum(cai * prop_class))
+        value = as.double(sum(ai * pland))
     )
 }
-
-
-
 

--- a/R/lsm_l_area_cv.R
+++ b/R/lsm_l_area_cv.R
@@ -109,8 +109,12 @@ lsm_l_area_cv.list <- function(landscape, directions = 8) {
 
 lsm_l_area_cv_calc <- function(landscape, directions){
 
-     area_cv <- dplyr::summarise(lsm_p_area_calc(landscape, directions = directions),
-                                 value = raster::cv(value))
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions)
+
+    # calculate cv
+     area_cv <- dplyr::summarise(area_patch, value = raster::cv(value))
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_area_cv.R
+++ b/R/lsm_l_area_cv.R
@@ -107,11 +107,12 @@ lsm_l_area_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_area_cv_calc <- function(landscape, directions){
+lsm_l_area_cv_calc <- function(landscape, directions, resolution = NULL){
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,
-                                  directions = directions)
+                                  directions = directions,
+                                  resolution = resolution)
 
     # calculate cv
      area_cv <- dplyr::summarise(area_patch, value = raster::cv(value))

--- a/R/lsm_l_area_mn.R
+++ b/R/lsm_l_area_mn.R
@@ -108,11 +108,12 @@ lsm_l_area_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_area_mn_calc <- function(landscape, directions){
+lsm_l_area_mn_calc <- function(landscape, directions, resolution = NULL){
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,
-                                  directions = directions)
+                                  directions = directions,
+                                  resolution = resolution)
 
     # calculate mean
     area_mean <- dplyr::summarise(area_patch, value = mean(value))

--- a/R/lsm_l_area_mn.R
+++ b/R/lsm_l_area_mn.R
@@ -110,8 +110,12 @@ lsm_l_area_mn.list <- function(landscape, directions = 8) {
 
 lsm_l_area_mn_calc <- function(landscape, directions){
 
-    area_mean <- dplyr::summarise(lsm_p_area_calc(landscape, directions = directions),
-                                  value = mean(value))
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions)
+
+    # calculate mean
+    area_mean <- dplyr::summarise(area_patch, value = mean(value))
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_area_sd.R
+++ b/R/lsm_l_area_sd.R
@@ -109,8 +109,12 @@ lsm_l_area_sd.list <- function(landscape, directions = 8) {
 # Not working yet!
 lsm_l_area_sd_calc <- function(landscape, directions){
 
-    area_sd <- dplyr::summarise(lsm_p_area_calc(landscape, directions = directions),
-                                value = stats::sd(value))
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions)
+
+    # calculate sd
+    area_sd <- dplyr::summarise(area_patch, value = stats::sd(value))
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_area_sd.R
+++ b/R/lsm_l_area_sd.R
@@ -107,11 +107,12 @@ lsm_l_area_sd.list <- function(landscape, directions = 8) {
 }
 
 # Not working yet!
-lsm_l_area_sd_calc <- function(landscape, directions){
+lsm_l_area_sd_calc <- function(landscape, directions, resolution = NULL){
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,
-                                  directions = directions)
+                                  directions = directions,
+                                  resolution = resolution)
 
     # calculate sd
     area_sd <- dplyr::summarise(area_patch, value = stats::sd(value))

--- a/R/lsm_l_cai_cv.R
+++ b/R/lsm_l_cai_cv.R
@@ -141,12 +141,13 @@ lsm_l_cai_cv.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_cai_cv_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_cai_cv_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     cai_cv <- dplyr::summarise(lsm_p_cai_calc(landscape,
                                               directions = directions,
                                               consider_boundary = consider_boundary,
-                                              edge_depth = edge_depth),
+                                              edge_depth = edge_depth,
+                                              resolution = resolution),
                                value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_cai_mn.R
+++ b/R/lsm_l_cai_mn.R
@@ -138,12 +138,13 @@ lsm_l_cai_mn.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_cai_mn_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_cai_mn_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
-    cai_mean <- dplyr::summarise(lsm_p_cai(landscape,
-                                           directions = directions,
-                                           consider_boundary = consider_boundary,
-                                           edge_depth = edge_depth),
+    cai_mean <- dplyr::summarise(lsm_p_cai_calc(landscape,
+                                                directions = directions,
+                                                consider_boundary = consider_boundary,
+                                                edge_depth = edge_depth,
+                                                resolution = resolution),
                                  value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_cai_sd.R
+++ b/R/lsm_l_cai_sd.R
@@ -140,12 +140,13 @@ lsm_l_cai_sd.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_cai_sd_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_cai_sd_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
-    cai_sd <- dplyr::summarise(lsm_p_cai(landscape,
-                                         directions = directions,
-                                         consider_boundary = consider_boundary,
-                                         edge_depth = edge_depth),
+    cai_sd <- dplyr::summarise(lsm_p_cai_calc(landscape,
+                                              directions = directions,
+                                              consider_boundary = consider_boundary,
+                                              edge_depth = edge_depth,
+                                              resolution = resolution),
                                value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_cv.R
+++ b/R/lsm_l_circle_cv.R
@@ -115,7 +115,8 @@ lsm_l_circle_cv.list <- function(landscape, directions = 8) {
 
 lsm_l_circle_cv_calc <- function(landscape, directions) {
 
-    circle_cv <- dplyr::summarize(lsm_p_circle_calc(landscape, directions = directions),
+    circle_cv <- dplyr::summarize(lsm_p_circle_calc(landscape,
+                                                    directions = directions),
                                   value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_cv.R
+++ b/R/lsm_l_circle_cv.R
@@ -113,10 +113,12 @@ lsm_l_circle_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_circle_cv_calc <- function(landscape, directions) {
+lsm_l_circle_cv_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
     circle_cv <- dplyr::summarize(lsm_p_circle_calc(landscape,
-                                                    directions = directions),
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_mn.R
+++ b/R/lsm_l_circle_mn.R
@@ -112,10 +112,12 @@ lsm_l_circle_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_circle_mn_calc <- function(landscape, directions) {
+lsm_l_circle_mn_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
     circle_mn <- dplyr::summarize(lsm_p_circle_calc(landscape,
-                                                    directions = directions),
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_mn.R
+++ b/R/lsm_l_circle_mn.R
@@ -114,7 +114,8 @@ lsm_l_circle_mn.list <- function(landscape, directions = 8) {
 
 lsm_l_circle_mn_calc <- function(landscape, directions) {
 
-    circle_mn <- dplyr::summarize(lsm_p_circle_calc(landscape, directions = directions),
+    circle_mn <- dplyr::summarize(lsm_p_circle_calc(landscape,
+                                                    directions = directions),
                                   value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_sd.R
+++ b/R/lsm_l_circle_sd.R
@@ -116,7 +116,8 @@ lsm_l_circle_sd.list <- function(landscape, directions = 8) {
 
 lsm_l_circle_sd_calc <- function(landscape, directions) {
 
-    circle_sd <- dplyr::summarize(lsm_p_circle_calc(landscape, directions = directions),
+    circle_sd <- dplyr::summarize(lsm_p_circle_calc(landscape,
+                                                    directions = directions),
                                   value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_circle_sd.R
+++ b/R/lsm_l_circle_sd.R
@@ -114,10 +114,12 @@ lsm_l_circle_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_circle_sd_calc <- function(landscape, directions) {
+lsm_l_circle_sd_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
     circle_sd <- dplyr::summarize(lsm_p_circle_calc(landscape,
-                                                    directions = directions),
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_cohesion.R
+++ b/R/lsm_l_cohesion.R
@@ -104,13 +104,13 @@ lsm_l_cohesion.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_cohesion_calc <- function(landscape, directions) {
+lsm_l_cohesion_calc <- function(landscape, directions, resolution = NULL) {
 
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    # convert to raster to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get number of cells
     ncells_landscape <- length(landscape[!is.na(landscape)])

--- a/R/lsm_l_cohesion.R
+++ b/R/lsm_l_cohesion.R
@@ -106,23 +106,36 @@ lsm_l_cohesion.list <- function(landscape, directions = 8) {
 
 lsm_l_cohesion_calc <- function(landscape, directions) {
 
-    resolution_xy <- prod(raster::res(landscape))
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    ncells_landscape <- dplyr::mutate(lsm_l_ta_calc(landscape, directions = directions),
-                                      value = value * 10000 / resolution_xy)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
-    ncells_patch <- dplyr::mutate(lsm_p_area_calc(landscape, directions = directions),
-                                  value = value * 10000 / resolution_xy)
+    # get number of cells
+    ncells_landscape <- length(landscape[!is.na(landscape)])
 
-    perim_patch <- lsm_p_perim_calc(landscape, directions = directions)
+    # get number of cells in each patch: area = n_cells * res / 10000
+    ncells_patch <- dplyr::mutate(lsm_p_area_calc(landscape,
+                                                  directions = directions,
+                                                  resolution = resolution),
+                                  value = value * 10000 / prod(resolution))
 
+    # get perim for each patch
+    perim_patch <- lsm_p_perim_calc(landscape,
+                                    directions = directions,
+                                    resolution = resolution)
+
+    # denominator for cohesion (perim / n_cells) for landscape
     denominator <- dplyr::summarise(dplyr::mutate(perim_patch,
                                                   value = value * sqrt(ncells_patch$value)),
                                     value = sum(value))
 
-    cohesion <- dplyr::mutate(dplyr::summarise(perim_patch, value = sum(value)),
+    # calcualte cohesion
+    cohesion <- dplyr::mutate(dplyr::summarise(perim_patch,
+                                               value = sum(value)),
                               value = (1 - (value / denominator$value)) *
-                                  ((1 - (1 / sqrt(ncells_landscape$value))) ^ - 1) * 100)
+                                  ((1 - (1 / sqrt(ncells_landscape))) ^ - 1) * 100)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_condent.R
+++ b/R/lsm_l_condent.R
@@ -129,7 +129,10 @@ lsm_l_condent.list <- function(landscape,
 
 lsm_l_condent_calc <- function(landscape, neighbourhood, ordered, base){
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to raster to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     cmh  <- rcpp_get_composition_vector(landscape)
 

--- a/R/lsm_l_contag.R
+++ b/R/lsm_l_contag.R
@@ -110,7 +110,10 @@ lsm_l_contag.list <- function(landscape, verbose = TRUE) {
 
 lsm_l_contag_calc <- function(landscape, verbose) {
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to raster to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     t <- length(get_unique_values(landscape)[[1]])
 

--- a/R/lsm_l_core_cv.R
+++ b/R/lsm_l_core_cv.R
@@ -138,12 +138,13 @@ lsm_l_core_cv.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_core_cv_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_core_cv_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core_cv <- dplyr::summarise(lsm_p_core_calc(landscape,
                                                 directions = directions,
                                                 consider_boundary = consider_boundary,
-                                                edge_depth = edge_depth),
+                                                edge_depth = edge_depth,
+                                                resolution = resolution),
                                 value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_core_mn.R
+++ b/R/lsm_l_core_mn.R
@@ -136,12 +136,13 @@ lsm_l_core_mn.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_core_mn_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_core_mn_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core_mean <- dplyr::summarise(lsm_p_core_calc(landscape,
                                                   directions = directions,
                                                   consider_boundary = consider_boundary,
-                                                  edge_depth = edge_depth),
+                                                  edge_depth = edge_depth,
+                                                  resolution = resolution),
                                   value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_core_sd.R
+++ b/R/lsm_l_core_sd.R
@@ -137,12 +137,13 @@ lsm_l_core_sd.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_core_sd_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_core_sd_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
     core_sd <- dplyr::summarise(lsm_p_core_calc(landscape,
                                                 directions = directions,
                                                 consider_boundary = consider_boundary,
-                                                edge_depth = edge_depth),
+                                                edge_depth = edge_depth,
+                                                resolution = resolution),
                                 value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_dcad.R
+++ b/R/lsm_l_dcad.R
@@ -135,10 +135,13 @@ lsm_l_dcad.list <- function(landscape,
     dplyr::mutate(dplyr::bind_rows(result, .id = "layer"),
                   layer = as.integer(layer))
 }
-lsm_l_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                            extent = NULL, resolution = NULL, crs = NULL){
 
     # get patch area
-    patch_area <- lsm_p_area_calc(landscape, directions = directions)
+    patch_area <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # summarise to total area
     total_area <- dplyr::summarise(patch_area, value = sum(value))
@@ -147,7 +150,8 @@ lsm_l_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth
     ncore_patch <- lsm_p_ncore_calc(landscape,
                                     directions = directions,
                                     consider_boundary = consider_boundary,
-                                    edge_depth = edge_depth)
+                                    edge_depth = edge_depth,
+                                    extent = extent, resolution = resolution, crs = crs)
 
     # summarise for total landscape
     dcad <- dplyr::mutate(dplyr::summarise(ncore_patch, value = sum(value)),

--- a/R/lsm_l_dcad.R
+++ b/R/lsm_l_dcad.R
@@ -137,15 +137,21 @@ lsm_l_dcad.list <- function(landscape,
 }
 lsm_l_dcad_calc <- function(landscape, directions, consider_boundary, edge_depth){
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get patch area
+    patch_area <- lsm_p_area_calc(landscape, directions = directions)
 
+    # summarise to total area
+    total_area <- dplyr::summarise(patch_area, value = sum(value))
+
+    # get core areas for each patch
     ncore_patch <- lsm_p_ncore_calc(landscape,
                                     directions = directions,
                                     consider_boundary = consider_boundary,
                                     edge_depth = edge_depth)
 
+    # summarise for total landscape
     dcad <- dplyr::mutate(dplyr::summarise(ncore_patch, value = sum(value)),
-                          value = (value / area_landscape$value) * 100)
+                          value = (value / total_area$value) * 100)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_dcore_cv.R
+++ b/R/lsm_l_dcore_cv.R
@@ -140,12 +140,14 @@ lsm_l_dcore_cv.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_dcore_cv_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_dcore_cv_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore_cv <- dplyr::summarise(lsm_p_ncore_calc(landscape,
                                                   directions = directions,
                                                   consider_boundary = consider_boundary,
-                                                  edge_depth = edge_depth),
+                                                  edge_depth = edge_depth,
+                                                  extent = extent, resolution = resolution, crs = crs),
                                  value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_dcore_mn.R
+++ b/R/lsm_l_dcore_mn.R
@@ -137,12 +137,14 @@ lsm_l_dcore_mn.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_dcore_mn_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_dcore_mn_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore_mean <- dplyr::summarise(lsm_p_ncore_calc(landscape,
                                                     directions = directions,
                                                     consider_boundary = consider_boundary,
-                                                    edge_depth = edge_depth),
+                                                    edge_depth = edge_depth,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                    value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_dcore_sd.R
+++ b/R/lsm_l_dcore_sd.R
@@ -139,12 +139,14 @@ lsm_l_dcore_sd.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_dcore_sd_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_dcore_sd_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                                extent = NULL, resolution = NULL, crs = NULL){
 
     dcore_sd <- dplyr::summarise(lsm_p_ncore_calc(landscape,
                                                   directions = directions,
                                                   consider_boundary = consider_boundary,
-                                                  edge_depth = edge_depth),
+                                                  edge_depth = edge_depth,
+                                                  extent = extent, resolution = resolution, crs = crs),
                                  value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_division.R
+++ b/R/lsm_l_division.R
@@ -109,12 +109,24 @@ lsm_l_division.list <- function(landscape, directions = 8) {
 
 lsm_l_division_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
-    division <- dplyr::mutate(area_patch, value = (value / area_landscape$value) ^ 2)
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
+    # summarise to total area
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # divison for each patch
+    division <- dplyr::mutate(area_patch, value = (value / area_total$value) ^ 2)
+
+    # summarise for whole landscape
     division <- dplyr::mutate(dplyr::summarise(division, value = sum(value)),
                               value = 1 - value)
 

--- a/R/lsm_l_division.R
+++ b/R/lsm_l_division.R
@@ -107,13 +107,7 @@ lsm_l_division.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_division_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_division_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_ed.R
+++ b/R/lsm_l_ed.R
@@ -121,11 +121,28 @@ lsm_l_ed.list <- function(landscape,
 
 lsm_l_ed_calc <- function(landscape, count_boundary, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    edge_landscape <- lsm_l_te_calc(landscape, count_boundary = count_boundary)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
-    ed <- dplyr::mutate(edge_landscape, value = value / area_landscape$value)
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise to total area
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # get total edge
+    edge_landscape <- lsm_l_te_calc(landscape,
+                                    count_boundary = count_boundary,
+                                    resolution = resolution)
+
+    # relative edge density
+    ed <- dplyr::mutate(edge_landscape,
+                        value = value / area_total$value)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_ed.R
+++ b/R/lsm_l_ed.R
@@ -119,13 +119,13 @@ lsm_l_ed.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_ed_calc <- function(landscape, count_boundary, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_l_ed_calc <- function(landscape, count_boundary, directions, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_enn_cv.R
+++ b/R/lsm_l_enn_cv.R
@@ -120,11 +120,13 @@ lsm_l_enn_cv.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_l_enn_cv_calc <- function(landscape, directions, verbose) {
+lsm_l_enn_cv_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn_cv <- dplyr::summarize(lsm_p_enn_calc(landscape,
-                             directions = directions, verbose = verbose),
-                             value = raster::cv(value))
+                                              directions = directions, verbose = verbose,
+                                              extent = extent, resolution = resolution, crs = crs),
+                               value = raster::cv(value))
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_enn_mn.R
+++ b/R/lsm_l_enn_mn.R
@@ -120,10 +120,12 @@ lsm_l_enn_mn.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_l_enn_mn_calc <- function(landscape, directions, verbose) {
+lsm_l_enn_mn_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn_mn <- dplyr::summarize(lsm_p_enn_calc(landscape,
-                                              directions = directions, verbose = verbose),
+                                              directions = directions, verbose = verbose,
+                                              extent = extent, resolution = resolution, crs = crs),
                                value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_enn_sd.R
+++ b/R/lsm_l_enn_sd.R
@@ -120,10 +120,12 @@ lsm_l_enn_sd.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_l_enn_sd_calc <- function(landscape, directions, verbose) {
+lsm_l_enn_sd_calc <- function(landscape, directions, verbose,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
     enn_sd <- dplyr::summarize(lsm_p_enn_calc(landscape,
-                                              directions = directions, verbose = verbose),
+                                              directions = directions, verbose = verbose,
+                                              extent = extent, resolution = resolution, crs = crs),
                                value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_ent.R
+++ b/R/lsm_l_ent.R
@@ -94,7 +94,10 @@ lsm_l_ent.list <- function(landscape, base = "log2") {
 
 lsm_l_ent_calc <- function(landscape, base){
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     cmh  <- rcpp_get_composition_vector(landscape)
 

--- a/R/lsm_l_frac_cv.R
+++ b/R/lsm_l_frac_cv.R
@@ -113,9 +113,11 @@ lsm_l_frac_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_frac_cv_calc <- function(landscape, directions){
+lsm_l_frac_cv_calc <- function(landscape, directions, resolution = NULL){
 
-    frac_cv <- dplyr::summarise(lsm_p_frac_calc(landscape, directions = directions),
+    frac_cv <- dplyr::summarise(lsm_p_frac_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_frac_mn.R
+++ b/R/lsm_l_frac_mn.R
@@ -112,9 +112,11 @@ lsm_l_frac_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_frac_mn_calc <- function(landscape, directions){
+lsm_l_frac_mn_calc <- function(landscape, directions, resolution = NULL){
 
-    frac_mean <- dplyr::summarise(lsm_p_frac(landscape, directions = directions),
+    frac_mean <- dplyr::summarise(lsm_p_frac_calc(landscape,
+                                                  directions = directions,
+                                                  resolution = resolution),
                                   value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_frac_sd.R
+++ b/R/lsm_l_frac_sd.R
@@ -112,9 +112,11 @@ lsm_l_frac_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_frac_sd_calc <- function(landscape, directions){
+lsm_l_frac_sd_calc <- function(landscape, directions, resolution = NULL){
 
-    frac_sd <- dplyr::summarise(lsm_p_frac_calc(landscape, directions = directions),
+    frac_sd <- dplyr::summarise(lsm_p_frac_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_gyrate_cv.R
+++ b/R/lsm_l_gyrate_cv.R
@@ -114,9 +114,12 @@ lsm_l_gyrate_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_gyrate_cv_calc <- function(landscape, directions) {
+lsm_l_gyrate_cv_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate_cv <- dplyr::summarize(lsm_p_gyrate_calc(landscape, directions = directions),
+    gyrate_cv <- dplyr::summarize(lsm_p_gyrate_calc(landscape,
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_gyrate_mn.R
+++ b/R/lsm_l_gyrate_mn.R
@@ -113,9 +113,12 @@ lsm_l_gyrate_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_gyrate_mn_calc <- function(landscape, directions) {
+lsm_l_gyrate_mn_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate_mn <- dplyr::summarize(lsm_p_gyrate_calc(landscape, directions = directions),
+    gyrate_mn <- dplyr::summarize(lsm_p_gyrate_calc(landscape,
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_gyrate_sd.R
+++ b/R/lsm_l_gyrate_sd.R
@@ -113,9 +113,12 @@ lsm_l_gyrate_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_gyrate_sd_calc <- function(landscape, directions) {
+lsm_l_gyrate_sd_calc <- function(landscape, directions,
+                                 extent = NULL, resolution = NULL, crs = NULL) {
 
-    gyrate_sd <- dplyr::summarize(lsm_p_gyrate_calc(landscape, directions = directions),
+    gyrate_sd <- dplyr::summarize(lsm_p_gyrate_calc(landscape,
+                                                    directions = directions,
+                                                    extent = extent, resolution = resolution, crs = crs),
                                   value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_iji.R
+++ b/R/lsm_l_iji.R
@@ -110,7 +110,10 @@ lsm_l_iji.list <- function(landscape, verbose = TRUE) {
 
 lsm_l_iji_calc <- function(landscape, verbose) {
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     adjacencies <- rcpp_get_coocurrence_matrix(landscape,
                                                as.matrix(4))

--- a/R/lsm_l_joinent.R
+++ b/R/lsm_l_joinent.R
@@ -127,7 +127,10 @@ lsm_l_joinent.list <- function(landscape,
 
 lsm_l_joinent_calc <- function(landscape, neighbourhood, ordered, base){
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     coh <- rcpp_get_coocurrence_vector(landscape,
                                        directions = as.matrix(neighbourhood),

--- a/R/lsm_l_lpi.R
+++ b/R/lsm_l_lpi.R
@@ -104,13 +104,18 @@ lsm_l_lpi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_lpi_calc <- function(landscape, directions) {
+lsm_l_lpi_calc <- function(landscape, directions, resolution = NULL) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get patch area
+    patch_area <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # summarise to total area
+    total_area <- dplyr::summarise(patch_area, value = sum(value))
 
-    lpi <- dplyr::summarise(dplyr::mutate(area_patch, lpi = (value / area_landscape$value) * 100),
+    # maximum value of patch_area / total_area
+    lpi <- dplyr::summarise(dplyr::mutate(patch_area, lpi = (value / total_area$value) * 100),
                             value = max(lpi))
 
     tibble::tibble(

--- a/R/lsm_l_mesh.R
+++ b/R/lsm_l_mesh.R
@@ -110,13 +110,25 @@ lsm_l_mesh.list <- function(landscape, directions = 8) {
 }
 lsm_l_mesh_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # conver to matrix
+    landscape <- raster::as.matrix(landscape)
 
+
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise to total area
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # calculate mesh first take area ^ 2, than sum for whole landscape dividied by landscape area total
     mesh <- dplyr::mutate(dplyr::summarise(dplyr::mutate(area_patch, value = value ^ 2),
                                            value = sum(value)),
-                          value = (value / area_landscape$value))
+                          value = (value / area_total$value))
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_mesh.R
+++ b/R/lsm_l_mesh.R
@@ -108,14 +108,7 @@ lsm_l_mesh.list <- function(landscape, directions = 8) {
     dplyr::mutate(dplyr::bind_rows(result, .id = "layer"),
                   layer = as.integer(layer))
 }
-lsm_l_mesh_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # conver to matrix
-    landscape <- raster::as.matrix(landscape)
-
+lsm_l_mesh_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_msidi.R
+++ b/R/lsm_l_msidi.R
@@ -106,9 +106,17 @@ lsm_l_msidi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_msidi_calc <- function(landscape, directions) {
+lsm_l_msidi_calc <- function(landscape, directions, resolution = NULL) {
 
-    msidi <- lsm_p_area_calc(landscape, directions = directions)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
+
+    msidi <- lsm_p_area_calc(landscape,
+                             directions = directions,
+                             resolution = resolution)
 
     msidi <- dplyr::summarise(dplyr::group_by(msidi, class),
                               value = sum(value))

--- a/R/lsm_l_msiei.R
+++ b/R/lsm_l_msiei.R
@@ -105,11 +105,17 @@ lsm_l_msiei.list <- function(landscape, directions = 8) {
 
 lsm_l_msiei_calc <- function(landscape, directions) {
 
-    msidi <- lsm_l_msidi_calc(landscape, directions = directions)
+    msidi <- lsm_p_area_calc(landscape, directions = directions)
 
-    pr <- lsm_l_pr_calc(landscape)
+    msidi <- dplyr::summarise(dplyr::group_by(msidi, class),
+                              value = sum(value))
 
-    msiei <- msidi$value / log(pr$value)
+    msidi <- dplyr::summarise(dplyr::mutate(msidi, value = (value / sum(value)) ^ 2),
+                              value = -log(sum(value)))
+
+    pr <- length(get_unique_values(landscape)[[1]])
+
+    msiei <- msidi$value / log(pr)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_msiei.R
+++ b/R/lsm_l_msiei.R
@@ -103,9 +103,11 @@ lsm_l_msiei.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_msiei_calc <- function(landscape, directions) {
+lsm_l_msiei_calc <- function(landscape, directions, resolution = NULL) {
 
-    msidi <- lsm_p_area_calc(landscape, directions = directions)
+    msidi <- lsm_p_area_calc(landscape,
+                             directions = directions,
+                             resolution = resolution)
 
     msidi <- dplyr::summarise(dplyr::group_by(msidi, class),
                               value = sum(value))

--- a/R/lsm_l_mutinf.R
+++ b/R/lsm_l_mutinf.R
@@ -128,7 +128,10 @@ lsm_l_mutinf.list <- function(landscape,
 
 lsm_l_mutinf_calc <- function(landscape, neighbourhood, ordered, base){
 
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     cmh  <- rcpp_get_composition_vector(landscape)
 

--- a/R/lsm_l_ndca.R
+++ b/R/lsm_l_ndca.R
@@ -136,12 +136,14 @@ lsm_l_ndca.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_ndca_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_l_ndca_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                            extent = NULL, resolution = NULL, crs = NULL){
 
     ndca <- dplyr::summarise(lsm_p_ncore_calc(landscape,
                                               directions = directions,
                                               consider_boundary = consider_boundary,
-                                              edge_depth = edge_depth),
+                                              edge_depth = edge_depth,
+                                              extent = extent, resolution = resolution, crs = crs),
                              value = sum(value))
 
     tibble::tibble(

--- a/R/lsm_l_np.R
+++ b/R/lsm_l_np.R
@@ -103,7 +103,8 @@ lsm_l_np.list <- function(landscape, directions = 8) {
 
 lsm_l_np_calc <- function(landscape, directions) {
 
-    n_patches <- dplyr::summarise(lsm_c_np_calc(landscape, directions = directions),
+    n_patches <- dplyr::summarise(lsm_c_np_calc(landscape,
+                                                directions = directions),
                                   value = sum(value))
 
     tibble::tibble(

--- a/R/lsm_l_pafrac.R
+++ b/R/lsm_l_pafrac.R
@@ -117,13 +117,13 @@ lsm_l_pafrac.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_l_pafrac_calc <- function(landscape, directions, verbose){
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_l_pafrac_calc <- function(landscape, directions, verbose, resolution = NULL){
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_para_cv.R
+++ b/R/lsm_l_para_cv.R
@@ -110,13 +110,7 @@ lsm_l_para_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_para_cv_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_para_cv_calc <- function(landscape, directions, resolution = NULL){
 
     para_cv <- dplyr::summarise(lsm_p_para_calc(landscape,
                                                 directions = directions,

--- a/R/lsm_l_para_cv.R
+++ b/R/lsm_l_para_cv.R
@@ -112,7 +112,15 @@ lsm_l_para_cv.list <- function(landscape, directions = 8) {
 
 lsm_l_para_cv_calc <- function(landscape, directions){
 
-    para_cv <- dplyr::summarise(lsm_p_para_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para_cv <- dplyr::summarise(lsm_p_para_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_para_mn.R
+++ b/R/lsm_l_para_mn.R
@@ -110,13 +110,7 @@ lsm_l_para_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_para_mn_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_para_mn_calc <- function(landscape, directions, resolution = NULL){
 
     para_mn <- dplyr::summarise(lsm_p_para_calc(landscape,
                                                 directions = directions,

--- a/R/lsm_l_para_mn.R
+++ b/R/lsm_l_para_mn.R
@@ -112,7 +112,15 @@ lsm_l_para_mn.list <- function(landscape, directions = 8) {
 
 lsm_l_para_mn_calc <- function(landscape, directions){
 
-    para_mn <- dplyr::summarise(lsm_p_para_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para_mn <- dplyr::summarise(lsm_p_para_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_para_sd.R
+++ b/R/lsm_l_para_sd.R
@@ -112,7 +112,15 @@ lsm_l_para_sd.list <- function(landscape, directions = 8) {
 
 lsm_l_para_sd_calc <- function(landscape, directions){
 
-    para_sd <- dplyr::summarise(lsm_p_para_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    para_sd <- dplyr::summarise(lsm_p_para_calc(landscape,
+                                                directions = directions,
+                                                resolution = resolution),
                                 value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_para_sd.R
+++ b/R/lsm_l_para_sd.R
@@ -110,13 +110,7 @@ lsm_l_para_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_para_sd_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_para_sd_calc <- function(landscape, directions, resolution = NULL){
 
     para_sd <- dplyr::summarise(lsm_p_para_calc(landscape,
                                                 directions = directions,

--- a/R/lsm_l_pd.R
+++ b/R/lsm_l_pd.R
@@ -105,13 +105,12 @@ lsm_l_pd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_pd_calc <- function(landscape, directions) {
+lsm_l_pd_calc <- function(landscape, directions, resolution = NULL) {
 
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # covner to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_pd.R
+++ b/R/lsm_l_pd.R
@@ -107,16 +107,35 @@ lsm_l_pd.list <- function(landscape, directions = 8) {
 
 lsm_l_pd_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    patch_density <- dplyr::mutate(lsm_l_np_calc(landscape, directions = directions),
-                                   value = (value / area_landscape$value) * 100)
+    # covner to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise for total landscape
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # number of patches for each class
+    number_patches <- lsm_c_np_calc(landscape,
+                                    directions = directions)
+
+    # summarise for total landscape
+    number_patches <- dplyr::summarise(number_patches, value = sum(value))
+
+    # relative patch density
+    patch_density <- (number_patches$value / area_total$value) * 100
 
     tibble::tibble(
         level = "landscape",
         class = as.integer(NA),
         id = as.integer(NA),
         metric = "pd",
-        value = as.double(patch_density$value)
+        value = as.double(patch_density)
     )
 }

--- a/R/lsm_l_pladj.R
+++ b/R/lsm_l_pladj.R
@@ -97,7 +97,9 @@ lsm_l_pladj.list <- function(landscape) {
 
 lsm_l_pladj_calc <- function(landscape) {
 
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     landscape_padded <- pad_raster(landscape,
                                    pad_raster_value = -999,

--- a/R/lsm_l_prd.R
+++ b/R/lsm_l_prd.R
@@ -100,13 +100,7 @@ lsm_l_prd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_prd_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_prd_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_prd.R
+++ b/R/lsm_l_prd.R
@@ -102,12 +102,26 @@ lsm_l_prd.list <- function(landscape, directions = 8) {
 
 lsm_l_prd_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise for total landscape
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # get number of classes
     pr_landscape <- lsm_l_pr_calc(landscape)
 
+    # relative number of classes
     prd <- dplyr::mutate(pr_landscape,
-                         value = (value / area_landscape$value) * 100)
+                         value = (value / area_total$value) * 100)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_rpr.R
+++ b/R/lsm_l_rpr.R
@@ -123,8 +123,8 @@ lsm_l_rpr_calc <- function(landscape, classes_max, verbose) {
 
         pr <- lsm_l_pr_calc(landscape)
 
-        rpr <- dplyr::pull(dplyr::mutate(pr, value = value / classes_max * 100),
-                           value)
+        rpr <- dplyr::mutate(pr, value = value / classes_max * 100)
+        rpr <- rpr$value
     }
 
     tibble::tibble(

--- a/R/lsm_l_rpr.R
+++ b/R/lsm_l_rpr.R
@@ -120,6 +120,7 @@ lsm_l_rpr_calc <- function(landscape, classes_max, verbose) {
     }
 
     else {
+
         pr <- lsm_l_pr_calc(landscape)
 
         rpr <- dplyr::pull(dplyr::mutate(pr, value = value / classes_max * 100),

--- a/R/lsm_l_shape_cv.R
+++ b/R/lsm_l_shape_cv.R
@@ -113,7 +113,19 @@ lsm_l_shape_cv.list <- function(landscape, directions = 8) {
 
 lsm_l_shape_cv_calc <- function(landscape, directions){
 
-    shape_cv <- dplyr::summarise(lsm_p_shape_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate cv
+    shape_cv <- dplyr::summarise(shape,
                                  value = raster::cv(value))
 
     tibble::tibble(

--- a/R/lsm_l_shape_cv.R
+++ b/R/lsm_l_shape_cv.R
@@ -111,13 +111,7 @@ lsm_l_shape_cv.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_shape_cv_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_shape_cv_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_l_shape_mn.R
+++ b/R/lsm_l_shape_mn.R
@@ -113,7 +113,19 @@ lsm_l_shape_mn.list <- function(landscape, directions = 8) {
 
 lsm_l_shape_mn_calc <- function(landscape, directions){
 
-    shape_mn <- dplyr::summarise(lsm_p_shape_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate mean
+    shape_mn <- dplyr::summarise(shape,
                                  value = mean(value))
 
     tibble::tibble(

--- a/R/lsm_l_shape_mn.R
+++ b/R/lsm_l_shape_mn.R
@@ -111,13 +111,7 @@ lsm_l_shape_mn.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_shape_mn_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_shape_mn_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_l_shape_sd.R
+++ b/R/lsm_l_shape_sd.R
@@ -113,7 +113,19 @@ lsm_l_shape_sd.list <- function(landscape, directions = 8) {
 
 lsm_l_shape_sd_calc <- function(landscape, directions){
 
-    shape_sd <- dplyr::summarise(lsm_p_shape_calc(landscape, directions = directions),
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
+    # shape index for each patch
+    shape <- lsm_p_shape_calc(landscape,
+                              directions = directions,
+                              resolution = resolution)
+
+    # calculate sd
+    shape_sd <- dplyr::summarise(shape,
                                  value = stats::sd(value))
 
     tibble::tibble(

--- a/R/lsm_l_shape_sd.R
+++ b/R/lsm_l_shape_sd.R
@@ -111,13 +111,7 @@ lsm_l_shape_sd.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_shape_sd_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_shape_sd_calc <- function(landscape, directions, resolution = NULL){
 
     # shape index for each patch
     shape <- lsm_p_shape_calc(landscape,

--- a/R/lsm_l_shdi.R
+++ b/R/lsm_l_shdi.R
@@ -99,17 +99,22 @@ lsm_l_shdi.list <- function(landscape) {
                   layer = as.integer(layer))
 }
 
-lsm_l_shdi_calc <- function(landscape) {
+lsm_l_shdi_calc <- function(landscape, resolution = NULL) {
 
-    area <- raster::ncell(landscape) # Do we need to exclude NAs?
+    # get class proportions (direction doesn't matter)
+    prop <- lsm_c_pland_calc(landscape,
+                             directions = 8,
+                             resolution = resolution)
 
-    p <- table(raster::values(landscape)) / area
+    prop <- dplyr::mutate(prop, value = value / 100)
 
-    H <- tibble::tibble(
+    shdi <- sum(-prop$value * log(prop$value, exp(1)))
+
+    tibble::tibble(
         level = 'landscape',
         class = as.integer(NA),
         id = as.integer(NA),
         metric = "shdi",
-        value = as.double(sum(-p * log(p, exp(1))))
+        value = as.double(shdi)
     )
 }

--- a/R/lsm_l_shdi.R
+++ b/R/lsm_l_shdi.R
@@ -101,7 +101,7 @@ lsm_l_shdi.list <- function(landscape) {
 
 lsm_l_shdi_calc <- function(landscape) {
 
-    area <- raster::ncell(landscape)
+    area <- raster::ncell(landscape) # Do we need to exclude NAs?
 
     p <- table(raster::values(landscape)) / area
 

--- a/R/lsm_l_shei.R
+++ b/R/lsm_l_shei.R
@@ -101,7 +101,7 @@ lsm_l_shei.list <- function(landscape){
 
 lsm_l_shei_calc <- function(landscape){
 
-    area <- raster::ncell(landscape)
+    area <- raster::ncell(landscape) # Do we need to exclude NAs?
 
     p <- table(raster::values(landscape)) / area
 

--- a/R/lsm_l_shei.R
+++ b/R/lsm_l_shei.R
@@ -99,18 +99,22 @@ lsm_l_shei.list <- function(landscape){
                   layer = as.integer(layer))
 }
 
-lsm_l_shei_calc <- function(landscape){
+lsm_l_shei_calc <- function(landscape, resolution = NULL){
 
-    area <- raster::ncell(landscape) # Do we need to exclude NAs?
+    # get class proportions (direction doesn't matter)
+    prop <- lsm_c_pland_calc(landscape,
+                             directions = 8,
+                             resolution = resolution)
 
-    p <- table(raster::values(landscape)) / area
+    prop <- dplyr::mutate(prop, value = value / 100)
+
+    shei <- sum(-prop$value * log(prop$value, exp(1))) / log(length(prop$value), exp(1))
 
     tibble::tibble(
         level = "landscape",
         class = as.integer(NA),
         id = as.integer(NA),
         metric = "shei",
-        value = as.double(sum(-p * log(p, exp(1))) /
-                              log(length(p), exp(1)))
+        value = as.double(shei)
     )
 }

--- a/R/lsm_l_sidi.R
+++ b/R/lsm_l_sidi.R
@@ -106,9 +106,11 @@ lsm_l_sidi.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_sidi_calc <- function(landscape, directions) {
+lsm_l_sidi_calc <- function(landscape, directions, resolution = NULL) {
 
-    sidi <- lsm_c_pland_calc(landscape, directions = directions)
+    sidi <- lsm_c_pland_calc(landscape,
+                             directions = directions,
+                             resolution = resolution)
 
     sidi <- dplyr::summarise(dplyr::mutate(sidi, value = (value / 100) ^ 2),
                              value = 1 - sum(value))

--- a/R/lsm_l_siei.R
+++ b/R/lsm_l_siei.R
@@ -106,9 +106,11 @@ lsm_l_siei.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_siei_calc <- function(landscape, directions) {
+lsm_l_siei_calc <- function(landscape, directions, resolution = NULL) {
 
-    sidi <- lsm_l_sidi_calc(landscape, directions = directions)
+    sidi <- lsm_l_sidi_calc(landscape,
+                            directions = directions,
+                            resolution = resolution)
 
     pr <- lsm_l_pr_calc(landscape)
 

--- a/R/lsm_l_split.R
+++ b/R/lsm_l_split.R
@@ -109,14 +109,26 @@ lsm_l_split.list <- function(landscape, directions = 8) {
 
 lsm_l_split_calc <- function(landscape, directions) {
 
-    area_landscape <- lsm_l_ta_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
+    # get patch area
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # summarise for total landscape
+    area_total <- dplyr::summarise(area_patch, value = sum(value))
+
+    # area squared for each patch
     split <- dplyr::mutate(area_patch, value = value ^ 2)
 
+    # sum of all patches divided by total area
     split <- dplyr::mutate(dplyr::summarise(split, value = sum(value)),
-                           value = (area_landscape$value ^ 2) / value)
+                           value = (area_total$value ^ 2) / value)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_split.R
+++ b/R/lsm_l_split.R
@@ -107,13 +107,7 @@ lsm_l_split.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_split_calc <- function(landscape, directions) {
-
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+lsm_l_split_calc <- function(landscape, directions, resolution = NULL) {
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape,

--- a/R/lsm_l_ta.R
+++ b/R/lsm_l_ta.R
@@ -102,10 +102,11 @@ lsm_l_ta.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_l_ta_calc <- function(landscape, directions) {
+lsm_l_ta_calc <- function(landscape, directions, resolution = NULL) {
 
     total_area <- dplyr::summarise(lsm_p_area_calc(landscape,
-                                                   directions = directions),
+                                                   directions = directions,
+                                                   resolution = resolution),
                                    value = sum(value))
 
     tibble::tibble(

--- a/R/lsm_l_ta.R
+++ b/R/lsm_l_ta.R
@@ -104,7 +104,8 @@ lsm_l_ta.list <- function(landscape, directions = 8) {
 
 lsm_l_ta_calc <- function(landscape, directions) {
 
-    total_area <- dplyr::summarise(lsm_p_area_calc(landscape, directions = directions),
+    total_area <- dplyr::summarise(lsm_p_area_calc(landscape,
+                                                   directions = directions),
                                    value = sum(value))
 
     tibble::tibble(

--- a/R/lsm_l_tca.R
+++ b/R/lsm_l_tca.R
@@ -135,12 +135,13 @@ lsm_l_tca.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_l_tca_calc <- function(landscape, directions, consider_boundary, edge_depth) {
+lsm_l_tca_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL) {
 
     total_core_area <- dplyr::summarise(lsm_p_core_calc(landscape,
                                                         directions = directions,
                                                         consider_boundary = consider_boundary,
-                                                        edge_depth = edge_depth),
+                                                        edge_depth = edge_depth,
+                                                        resolution = resolution),
                                         value = sum(value))
 
     tibble::tibble(

--- a/R/lsm_l_te.R
+++ b/R/lsm_l_te.R
@@ -103,13 +103,17 @@ lsm_l_te.list <- function(landscape, count_boundary = FALSE) {
                   layer = as.integer(layer))
 }
 
-lsm_l_te_calc <- function(landscape, count_boundary = FALSE){
+lsm_l_te_calc <- function(landscape, count_boundary, resolution = NULL){
 
-    resolution_xy <- raster::res(landscape)
-    resolution_x <- resolution_xy[[1]]
-    resolution_y <- resolution_xy[[2]]
+    # conver raster to matrix
+    if (class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
-    landscape <- raster::as.matrix(landscape)
+    # get resolution in x-y directions
+    resolution_x <- resolution[[1]]
+    resolution_y <- resolution[[2]]
 
     if(isTRUE(count_boundary)){
         landscape <- pad_raster(landscape = landscape,

--- a/R/lsm_p_area.R
+++ b/R/lsm_p_area.R
@@ -109,13 +109,16 @@ lsm_p_area.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_area_calc <- function(landscape, directions){
-
-    # factor to convert cell to area
-    factor_ha <- prod(raster::res(landscape)) / 10000
+lsm_p_area_calc <- function(landscape, directions, resolution = NULL){
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
+
+    # factor to convert cell to area
+    factor_ha <- prod(resolution) / 10000
 
     # get unique class id
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_cai.R
+++ b/R/lsm_p_cai.R
@@ -144,16 +144,27 @@ lsm_p_cai.list <- function(landscape,
 
 lsm_p_cai_calc <- function(landscape, directions, consider_boundary, edge_depth){
 
+    # get resolution of raster
+    resolution <- raster::res(landscape)
+
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
+
     # get patch area
-    area_patch <- dplyr::mutate(lsm_p_area_calc(landscape = landscape,
-                                                directions = directions),
+    area_patch <- lsm_p_area_calc(landscape = landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # convert from ha to sqm
+    area_patch <- dplyr::mutate(area_patch,
                                 value = value * 10000)
 
     # get core area
     core_patch <- lsm_p_core_calc(landscape,
                                   directions = directions,
                                   consider_boundary = consider_boundary,
-                                  edge_depth = edge_depth)
+                                  edge_depth = edge_depth,
+                                  resolution = resolution)
 
     # calculate CAI index
     cai_patch <- dplyr::mutate(core_patch,

--- a/R/lsm_p_cai.R
+++ b/R/lsm_p_cai.R
@@ -142,13 +142,14 @@ lsm_p_cai.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_p_cai_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_p_cai_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL){
 
-    # get resolution of raster
-    resolution <- raster::res(landscape)
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape = landscape,

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -125,7 +125,6 @@ lsm_p_circle_calc <- function(landscape, directions,
                                       crs =crs)
     }
 
-
     # get resolution of landscape
     resolution <- raster::res(landscape)
     resolution_x <- resolution[[1]]
@@ -144,8 +143,18 @@ lsm_p_circle_calc <- function(landscape, directions,
                                          class = patches_class,
                                          directions = directions)[[1]]
 
+        landscape_boundaries <- raster::boundaries(landscape_labeled,
+                                                   directions = 4,
+                                                   asNA = TRUE)
+
         # convert to points
-        points_class <- raster::rasterToPoints(landscape_labeled)
+        points_class_labeled <- data.frame(raster::rasterToPoints(landscape_labeled))
+        points_class_boundaries <- data.frame(raster::rasterToPoints(landscape_boundaries))
+
+        # keep only points that are boundary (but with original patch id)
+        points_class <- dplyr::semi_join(x = points_class_labeled,
+                                         y = points_class_boundaries,
+                                         by = c("x","y"))
 
         # get circle radius around patch
         circle <- rcpp_get_circle(as.matrix(points_class),
@@ -172,7 +181,3 @@ lsm_p_circle_calc <- function(landscape, directions,
         value = as.double(circle_patch$value)
     )
 }
-
-
-
-

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -133,6 +133,9 @@ lsm_p_circle_calc <- function(landscape, directions,
     # get patch area
     area_patch <- lsm_p_area_calc(landscape, directions = directions)
 
+    # patches with only 1 cell
+    one_cell <- which(area_patch$value == prod(resolution) / 10000 )
+
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]
 
@@ -166,12 +169,17 @@ lsm_p_circle_calc <- function(landscape, directions,
 
         tibble::tibble(class = patches_class,
                        value = circle[,2])
-
     })
 
     # calculate circle metric
-    circle_patch <- dplyr::mutate(dplyr::bind_rows(circle_patch),
+    circle_patch <- dplyr::bind_rows(circle_patch)
+
+    # calculate circle metric
+    circle_patch <- dplyr::mutate(circle_patch,
                                   value = 1 - ((area_patch$value * 10000) / value))
+
+    # set all one-cell patches to 0
+    circle_patch$value[one_cell] <- 0
 
     tibble::tibble(
         level = "patch",

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -114,14 +114,20 @@ lsm_p_circle.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_circle_calc <- function(landscape, directions, resolution = NULL, landscape_raster = NULL) {
+lsm_p_circle_calc <- function(landscape, directions,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
+    # use raster instead of landscape
     if(class(landscape) == "matrix") {
-        landscape <- landscape_raster
-        resolution <- raster::res(landscape)
+        landscape <- matrix_to_raster(landscape,
+                                      extent = extent,
+                                      resolution = resolution,
+                                      crs =crs)
     }
 
+
     # get resolution of landscape
+    resolution <- raster::res(landscape)
     resolution_x <- resolution[[1]]
     resolution_y <- resolution[[2]]
 

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -114,12 +114,16 @@ lsm_p_circle.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_circle_calc <- function(landscape, directions) {
+lsm_p_circle_calc <- function(landscape, directions, resolution = NULL, landscape_raster = NULL) {
+
+    if(class(landscape) == "matrix") {
+        landscape <- landscape_raster
+        resolution <- raster::res(landscape)
+    }
 
     # get resolution of landscape
-    resolution_xy <- raster::res(landscape)
-    resolution_x <- resolution_xy[[1]]
-    resolution_y <- resolution_xy[[2]]
+    resolution_x <- resolution[[1]]
+    resolution_y <- resolution[[2]]
 
     # get patch area
     area_patch <- lsm_p_area_calc(landscape, directions = directions)

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -163,6 +163,8 @@ lsm_p_circle_calc <- function(landscape, directions,
         circle <- rcpp_get_circle(as.matrix(points_class),
                                   resolution_x = resolution_x,
                                   resolution_y = resolution_y)
+        # calculate circle area
+        circle[, 2] <- pi * ((circle[, 2]  /2) ^ 2)
 
         # sort according to patch id
         circle <- matrix(circle[order(circle[,1]),], ncol = 2)

--- a/R/lsm_p_contig.R
+++ b/R/lsm_p_contig.R
@@ -125,7 +125,9 @@ lsm_p_contig.list <- function(landscape, directions = 8) {
 lsm_p_contig_calc <- function(landscape, directions) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get unique values
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_core.R
+++ b/R/lsm_p_core.R
@@ -132,13 +132,13 @@ lsm_p_core.list <- function(landscape, directions = 8,
                   layer = as.integer(layer))
 }
 
-lsm_p_core_calc <- function(landscape, directions, consider_boundary, edge_depth) {
-
-    # get resolution of raster
-    resolution_xy <- raster::res(landscape)
+lsm_p_core_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL) {
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]
@@ -190,7 +190,7 @@ lsm_p_core_calc <- function(landscape, directions, consider_boundary, edge_depth
         cells_patch <- table(landscape_labeled)
 
         # all cells minus edge cells equal core and convert to ha
-        core_area <- (cells_patch - cells_edge_patch) * prod(resolution_xy) / 10000
+        core_area <- (cells_patch - cells_edge_patch) * prod(resolution) / 10000
 
         tibble::tibble(class = patches_class,
                        value = core_area)

--- a/R/lsm_p_enn.R
+++ b/R/lsm_p_enn.R
@@ -120,7 +120,11 @@ lsm_p_enn.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_p_enn_calc <- function(landscape, directions, verbose) {
+lsm_p_enn_calc <- function(landscape, directions, verbose, landscape_raster = NULL) {
+
+    if(class(landscape) == "matrix") {
+        landscape <- landscape_raster
+    }
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_enn.R
+++ b/R/lsm_p_enn.R
@@ -120,11 +120,17 @@ lsm_p_enn.list <- function(landscape, directions = 8, verbose = TRUE) {
                   layer = as.integer(layer))
 }
 
-lsm_p_enn_calc <- function(landscape, directions, verbose, landscape_raster = NULL) {
+lsm_p_enn_calc <- function(landscape, directions, verbose,
+                           extent = NULL, resolution = NULL, crs = NULL) {
 
+    # use raster instead of landscape
     if(class(landscape) == "matrix") {
-        landscape <- landscape_raster
+        landscape <- matrix_to_raster(landscape,
+                                      extent = extent,
+                                      resolution = resolution,
+                                      crs =crs)
     }
+
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_frac.R
+++ b/R/lsm_p_frac.R
@@ -116,11 +116,21 @@ lsm_p_frac.list <- function(landscape, directions = 8) {
 
 lsm_p_frac_calc <- function(landscape, directions){
 
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # conver to matrix
+    landscape <- raster::as.matrix(landscape)
+
     # get patch perimeter
-    perimeter_patch <- lsm_p_perim_calc(landscape, directions = directions)
+    perimeter_patch <- lsm_p_perim_calc(landscape,
+                                        directions = directions,
+                                        resolution = resolution)
 
     # get patch area
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # calculate frac
     frac_patch <- dplyr::mutate(area_patch,

--- a/R/lsm_p_frac.R
+++ b/R/lsm_p_frac.R
@@ -114,13 +114,13 @@ lsm_p_frac.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_frac_calc <- function(landscape, directions){
+lsm_p_frac_calc <- function(landscape, directions, resolution = NULL){
 
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # conver to matrix
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get patch perimeter
     perimeter_patch <- lsm_p_perim_calc(landscape,

--- a/R/lsm_p_gyrate.R
+++ b/R/lsm_p_gyrate.R
@@ -111,7 +111,11 @@ lsm_p_gyrate.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_gyrate_calc <- function(landscape, directions) {
+lsm_p_gyrate_calc <- function(landscape, directions, landscape_raster = NULL) {
+
+    if(class(landscape) == "matrix") {
+        landscape <- landscape_raster
+    }
 
     # get uniuqe class id
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_gyrate.R
+++ b/R/lsm_p_gyrate.R
@@ -111,11 +111,17 @@ lsm_p_gyrate.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_gyrate_calc <- function(landscape, directions, landscape_raster = NULL) {
+lsm_p_gyrate_calc <- function(landscape, directions,
+                              extent = NULL, resolution = NULL, crs = NULL) {
 
+    # use raster instead of landscape
     if(class(landscape) == "matrix") {
-        landscape <- landscape_raster
+        landscape <- matrix_to_raster(landscape,
+                                      extent = extent,
+                                      resolution = resolution,
+                                      crs =crs)
     }
+
 
     # get uniuqe class id
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_gyrate.R
+++ b/R/lsm_p_gyrate.R
@@ -136,13 +136,11 @@ lsm_p_gyrate_calc <- function(landscape, directions) {
         # create full data set with raster-points and patch centroids
         full_data <- dplyr::left_join(x = points_class, y = centroid, by = "id")
 
-        # calculate distance from each cell center to centroid and take mean
-        gyrate_class <- dplyr::summarise(
-            dplyr::group_by(
-                dplyr::mutate(full_data, dist = sqrt((x - x_centroid) ^ 2 + (y - y_centroid) ^ 2)),
-                id),
-            value = mean(dist)
-            )
+        # calculate distance from each cell center to centroid
+        gyrate_class <- dplyr::mutate(full_data, dist = sqrt((x - x_centroid) ^ 2 + (y - y_centroid) ^ 2))
+
+        # mean distance for each patch
+        gyrate_class <- dplyr::summarise(dplyr::group_by(gyrate_class, id), value = mean(dist))
 
         tibble::tibble(class = as.integer(patches_class),
                        value = as.double(gyrate_class$value))

--- a/R/lsm_p_ncore.R
+++ b/R/lsm_p_ncore.R
@@ -145,13 +145,19 @@ lsm_p_ncore.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_p_ncore_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL, landscape_raster = NULL){
+lsm_p_ncore_calc <- function(landscape, directions, consider_boundary, edge_depth,
+                             extent = NULL, resolution = NULL, crs = NULL){
 
+    # use raster instead of landscape
     if(class(landscape) == "matrix") {
-        landscape <- landscape_raster
-        resolution <- raster::res(landscape)
-
+        landscape <- matrix_to_raster(landscape,
+                                      extent = extent,
+                                      resolution = resolution,
+                                      crs =crs)
     }
+
+    # get resolution (could go in else{})
+    resolution <- raster::res(landscape)
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_ncore.R
+++ b/R/lsm_p_ncore.R
@@ -151,13 +151,13 @@ lsm_p_ncore_calc <- function(landscape, directions, consider_boundary, edge_dept
     classes <- get_unique_values(landscape)[[1]]
 
     # get resolution of raster
-    resolution_xy <- raster::res(landscape)
+    resolution <- raster::res(landscape)
 
     # consider landscape boundary for core definition
     if(!consider_boundary) {
         # create empty raster for matrix_to_raster()
-        landscape_empty <- raster::raster(x = raster::extent(landscape) + (2 * resolution_xy),
-                                          resolution = resolution_xy,
+        landscape_empty <- raster::raster(x = raster::extent(landscape) + (2 * resolution),
+                                          resolution = resolution,
                                           crs = raster::crs(landscape))
     }
 

--- a/R/lsm_p_ncore.R
+++ b/R/lsm_p_ncore.R
@@ -145,13 +145,16 @@ lsm_p_ncore.list <- function(landscape,
                   layer = as.integer(layer))
 }
 
-lsm_p_ncore_calc <- function(landscape, directions, consider_boundary, edge_depth){
+lsm_p_ncore_calc <- function(landscape, directions, consider_boundary, edge_depth, resolution = NULL, landscape_raster = NULL){
+
+    if(class(landscape) == "matrix") {
+        landscape <- landscape_raster
+        resolution <- raster::res(landscape)
+
+    }
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]
-
-    # get resolution of raster
-    resolution <- raster::res(landscape)
 
     # consider landscape boundary for core definition
     if(!consider_boundary) {

--- a/R/lsm_p_para.R
+++ b/R/lsm_p_para.R
@@ -110,13 +110,13 @@ lsm_p_para.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_para_calc <- function(landscape, directions){
+lsm_p_para_calc <- function(landscape, directions, resolution = NULL){
 
-    # get resolution
-    resolution <- raster::res(landscape)
-
-    # conver to matrix
-    landscape <- raster::as.matrix(landscape)
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get perim
     perimeter_patch <- lsm_p_perim_calc(landscape,

--- a/R/lsm_p_para.R
+++ b/R/lsm_p_para.R
@@ -112,11 +112,21 @@ lsm_p_para.list <- function(landscape, directions = 8) {
 
 lsm_p_para_calc <- function(landscape, directions){
 
+    # get resolution
+    resolution <- raster::res(landscape)
+
+    # conver to matrix
+    landscape <- raster::as.matrix(landscape)
+
     # get perim
-    perimeter_patch <- lsm_p_perim_calc(landscape, directions = directions)
+    perimeter_patch <- lsm_p_perim_calc(landscape,
+                                        directions = directions,
+                                        resolution = resolution)
 
     # get area
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
 
     # calculate ratio between area and perim
     para_patch <- dplyr::mutate(area_patch, value = perimeter_patch$value /

--- a/R/lsm_p_perim.R
+++ b/R/lsm_p_perim.R
@@ -100,15 +100,17 @@ lsm_p_perim.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_perim_calc <- function(landscape, directions) {
+lsm_p_perim_calc <- function(landscape, directions, resolution = NULL) {
+
+    # convert to matrix
+    if(class(landscape) != "matrix") {
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get dimensions of raster
-    resolution_xy <- raster::res(landscape)
-    resolution_x <- resolution_xy[[1]]
-    resolution_y <- resolution_xy[[2]]
-
-    # conver to matrix
-    landscape <- raster::as.matrix(landscape)
+    resolution_x <- resolution[[1]]
+    resolution_y <- resolution[[2]]
 
     # get unique classes
     classes <- get_unique_values(landscape)[[1]]

--- a/R/lsm_p_shape.R
+++ b/R/lsm_p_shape.R
@@ -112,13 +112,13 @@ lsm_p_shape.list <- function(landscape, directions = 8) {
                   layer = as.integer(layer))
 }
 
-lsm_p_shape_calc <- function(landscape, directions){
-
-    # get resolution
-    resolution <- raster::res(landscape)
+lsm_p_shape_calc <- function(landscape, directions, resolution = NULL){
 
     # convert to matrix
-    landscape <- raster::as.matrix(landscape)
+    if (class(landscape) != "matrix"){
+        resolution <- raster::res(landscape)
+        landscape <- raster::as.matrix(landscape)
+    }
 
     # get perimeter of patches
     perimeter_patch <- lsm_p_perim_calc(landscape,

--- a/R/lsm_p_shape.R
+++ b/R/lsm_p_shape.R
@@ -114,10 +114,23 @@ lsm_p_shape.list <- function(landscape, directions = 8) {
 
 lsm_p_shape_calc <- function(landscape, directions){
 
-    perimeter_patch <- lsm_p_perim_calc(landscape, directions = directions)
+    # get resolution
+    resolution <- raster::res(landscape)
 
-    area_patch <- lsm_p_area_calc(landscape, directions = directions)
+    # convert to matrix
+    landscape <- raster::as.matrix(landscape)
 
+    # get perimeter of patches
+    perimeter_patch <- lsm_p_perim_calc(landscape,
+                                        directions = directions,
+                                        resolution = resolution)
+
+    # get area of patches
+    area_patch <- lsm_p_area_calc(landscape,
+                                  directions = directions,
+                                  resolution = resolution)
+
+    # calculate shape index
     shape_patch <- dplyr::mutate(area_patch,
                                  value = value * 10000,
                                  n = trunc(sqrt(value)),

--- a/R/matrix_to_raster.R
+++ b/R/matrix_to_raster.R
@@ -6,13 +6,13 @@
 #' @param landscape RasterLayer.
 #' @param landscape_empty If true, RasterLayer is landscape_empty
 #' @param to_disk If TRUE raster will be saved to disk.
-#' @param x Extent of RasterLayer.
+#' @param extent Extent of RasterLayer.
 #' @param resolution Resolution of RasterLayer.
 #' @param crs CRS of raster layer.
 #'
 #' @details
 #' Converts `matrix` to a raster with same characteristics as `landscape`. Either
-#' `landscape` or `x`, `resolution` and `crs` must be specified.
+#' `landscape` or `extent`, `resolution` and `crs` must be specified.
 #'
 #' @return raster
 #'
@@ -29,7 +29,7 @@
 matrix_to_raster <- function(matrix,
                              landscape = NULL,
                              landscape_empty = FALSE,
-                             x = NULL,
+                             extent = NULL,
                              resolution = NULL,
                              crs = NULL,
                              to_disk = FALSE) {
@@ -48,16 +48,15 @@ matrix_to_raster <- function(matrix,
     }
   }
 
-  else if(!all(c(is.null(x), is.null(resolution), is.null(crs)))){
-    landscape_empty <- raster::raster(x = x,
+  else if(!all(c(is.null(extent), is.null(resolution), is.null(crs)))){
+    landscape_empty <- raster::raster(x = extent,
                                       resolution = resolution,
                                       crs = crs)
   }
 
   else{
-    stop("Either 'landscape' or x & resolution & crs must be specified")
+    stop("Either 'landscape' or 'extent' & 'resolution' & 'crs' must be specified")
   }
-
 
     # create raster on disk
     if(to_disk){

--- a/R/pad_raster.R
+++ b/R/pad_raster.R
@@ -92,8 +92,6 @@ pad_raster.matrix <- function(landscape,
                               pad_raster_cells = 1,
                               global = FALSE) {
 
-    # landscape <- raster::as.matrix(landscape)
-
     pad_raster_internal(landscape,
                         pad_raster_value = pad_raster_value,
                         pad_raster_cells = pad_raster_cells,

--- a/R/sample_lsm.R
+++ b/R/sample_lsm.R
@@ -205,13 +205,18 @@ sample_lsm_int <- function(landscape, what, shape, points, size, ...) {
 
     results_landscapes <- lapply(X = seq_along(landscape_plots),
                                  FUN = function(current_plot) {
-                                     area <- dplyr::pull(lsm_l_ta(landscape_plots[[current_plot]]), value)
 
-                                     result_plot <- dplyr::mutate(
-                                         calculate_lsm(landscape = landscape_plots[[current_plot]], what = what, ...),
-                                         plot_id = current_plot, percentage_inside = (area / maximum_area) * 100)
+                                     area <- lsm_l_ta_calc(landscape_plots[[current_plot]],
+                                                           directions = 8)
+
+                                    result <- calculate_lsm(landscape = landscape_plots[[current_plot]], what = what, ...)
+
+                                     result_plot <- dplyr::mutate(result,
+                                                                  plot_id = current_plot,
+                                                                  percentage_inside = (area$value / maximum_area) * 100)
 
                                      result_plot <- result_plot[, c(1, 7, 2, 3, 4, 5, 6, 8)]
+
                                      return(result_plot)
                                      }
                                  )

--- a/man/matrix_to_raster.Rd
+++ b/man/matrix_to_raster.Rd
@@ -5,7 +5,7 @@
 \title{matrix_to_raster}
 \usage{
 matrix_to_raster(matrix, landscape = NULL, landscape_empty = FALSE,
-  x = NULL, resolution = NULL, crs = NULL, to_disk = FALSE)
+  extent = NULL, resolution = NULL, crs = NULL, to_disk = FALSE)
 }
 \arguments{
 \item{matrix}{matrix with values.}
@@ -14,7 +14,7 @@ matrix_to_raster(matrix, landscape = NULL, landscape_empty = FALSE,
 
 \item{landscape_empty}{If true, RasterLayer is landscape_empty}
 
-\item{x}{Extent of RasterLayer.}
+\item{extent}{Extent of RasterLayer.}
 
 \item{resolution}{Resolution of RasterLayer.}
 
@@ -30,7 +30,7 @@ Adding padding to raster
 }
 \details{
 Converts \code{matrix} to a raster with same characteristics as \code{landscape}. Either
-\code{landscape} or \code{x}, \code{resolution} and \code{crs} must be specified.
+\code{landscape} or \code{extent}, \code{resolution} and \code{crs} must be specified.
 }
 \examples{
 test_matrix <- raster::as.matrix(augusta_nlcd)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -268,8 +268,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_landscapemetrics_rcpp_get_offdiagonal_vector", (DL_FUNC) &_landscapemetrics_rcpp_get_offdiagonal_vector, 2},
     {"_landscapemetrics_rcpp_get_nearest_neighbor", (DL_FUNC) &_landscapemetrics_rcpp_get_nearest_neighbor, 1},
     {"_landscapemetrics_rcpp_get_unique_values", (DL_FUNC) &_landscapemetrics_rcpp_get_unique_values, 2},
-    {"ccl_4",                                              (DL_FUNC) &ccl_4,                                              1},
-    {"ccl_8",                                              (DL_FUNC) &ccl_8,                                              1},
+    {"ccl_4", (DL_FUNC) &ccl_4, 1},
+    {"ccl_8", (DL_FUNC) &ccl_8, 1},
     {NULL, NULL, 0}
 };
 

--- a/src/rcpp_get_circle.cpp
+++ b/src/rcpp_get_circle.cpp
@@ -40,6 +40,9 @@ arma::mat rcpp_get_circle(arma::mat points, double resolution_x, double resoluti
     id = points.col(2);
     unique_id = id(arma::find_unique(id));
 
+    resolution_x = resolution_x / 2;
+    resolution_y = resolution_y / 2;
+
     circle.set_size(unique_id.n_elem, 2);
 
     for(int i = 0; i < unique_id.n_elem; i++){

--- a/src/rcpp_get_circle.cpp
+++ b/src/rcpp_get_circle.cpp
@@ -75,7 +75,7 @@ arma::mat rcpp_get_circle(arma::mat points, double resolution_x, double resoluti
         }
 
         circle(i, 0) = class_id;
-        circle(i, 1) = std::pow((max_dist_fun(points_corner) / 2), 2) * arma::datum::pi;
+        circle(i, 1) = max_dist_fun(points_corner); // std::pow((max_dist_fun(points_corner) / 2), 2) * arma::datum::pi;
     }
 
     return circle;

--- a/vignettes/getstarted.Rmd
+++ b/vignettes/getstarted.Rmd
@@ -171,7 +171,6 @@ patch_metrics_full_names
 In `calculate_lsm` this exists as option (`full_name = TRUE`).
 
 ```{r}
-calculate_lsm(landscape, what = c("lsm_c_pland", "lsm_l_ta", "lsm_l_te"), 
+calculate_lsm(landscape, what = c("lsm_c_pland", "lsm_l_ta", "lsm_l_te"),
               full_name = TRUE)
-
 ```


### PR DESCRIPTION
`calculate_lsm()` now only converts once to a matrix and passes the matrix to all functions (including some additional information where needed, e.g. the resolution). This requires the internal `lsm_x_xxx_calc()` functions to have some additional arguments that are normally set to NULL (e.g. `resolution = NULL`). Also, all functions now test if the input is already a `matrix` or not (and convert only if not). This is necessaire that all `lsm_x_xxx()` functions also work outside `calculate_lsm()` 