### PR TITLE
Updates the way of calculating `lsm_l_ent()` and thus `lsm_l_condent(…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# landscapemetrics 1.0.2
+* Improvements
+    * Updates the way of calculating `lsm_l_ent()` and thus `lsm_l_condent()` and `lsm_l_mutinf()`. (Explanation: Variable x is a color of a cell and y is a color of the cell but located just next to the focus cell. When you calculate H(z) from the histogram of all cells in the landscape (SHDI), z is not exactly the same as x or y. The way to do it consistently is to calculate H(x) and H(y) as entropies of marginal distributions x and y calculated from the co-occurrence matrix.)
+
 # landscapemetrics 1.0.1
 * Bugfixes
     * Bugfix in `lsm_c_ai()` if only one class and NA values were present

--- a/R/lsm_l_condent.R
+++ b/R/lsm_l_condent.R
@@ -154,14 +154,15 @@ lsm_l_condent_calc <- function(landscape, neighbourhood, ordered, base){
         landscape <- raster::as.matrix(landscape)
     }
 
-    cmh  <- rcpp_get_composition_vector(landscape)
+    com <- rcpp_get_coocurrence_matrix(landscape,
+                                       directions = as.matrix(neighbourhood))
+    com_c <- colSums(com)
 
     coh <- rcpp_get_coocurrence_vector(landscape,
                                        directions = as.matrix(neighbourhood),
                                        ordered = ordered)
 
-    comp <- rcpp_get_entropy(cmh, base)
-
+    comp <- rcpp_get_entropy(com_c, base)
     cplx <- rcpp_get_entropy(coh, base)
 
     conf <- cplx - comp

--- a/R/lsm_l_ent.R
+++ b/R/lsm_l_ent.R
@@ -1,8 +1,11 @@
 #' ENT (landscape level)
 #'
-#' @description Shannon entropy
+#' @description A metric of a compositional complexity of a pattern (a pattern
+#' diversity)
 #'
 #' @param landscape Raster* Layer, Stack, Brick or a list of rasterLayers.
+#' @param neighbourhood The number of directions in which cell adjacencies are considered as neighbours:
+#' 4 (rook's case) or 8 (queen's case). The default is 4.
 #' @param base The unit in which entropy is measured.
 #' The default is "log2", which compute entropy in "bits".
 #' "log" and "log10" can be also used.
@@ -28,14 +31,19 @@
 #' landscape complexity. https://doi.org/10.1101/383281
 #'
 #' @export
-lsm_l_ent <- function(landscape, base = "log2") UseMethod("lsm_l_ent")
+lsm_l_ent <- function(landscape,
+                      neighbourhood,
+                      base) UseMethod("lsm_l_ent")
 
 #' @name lsm_l_ent
 #' @export
-lsm_l_ent.RasterLayer <- function(landscape, base = "log2") {
+lsm_l_ent.RasterLayer <- function(landscape,
+                                  neighbourhood = 4,
+                                  base = "log2") {
 
     result <- lapply(X = raster::as.list(landscape),
                      FUN = lsm_l_ent_calc,
+                     neighbourhood = neighbourhood,
                      base = base)
 
     layer <- rep(seq_len(length(result)),
@@ -48,10 +56,13 @@ lsm_l_ent.RasterLayer <- function(landscape, base = "log2") {
 
 #' @name lsm_l_ent
 #' @export
-lsm_l_ent.RasterStack <- function(landscape, base = "log2") {
+lsm_l_ent.RasterStack <- function(landscape,
+                                  neighbourhood = 4,
+                                  base = "log2") {
 
     result <- lapply(X = raster::as.list(landscape),
                      FUN = lsm_l_ent_calc,
+                     neighbourhood = neighbourhood,
                      base = base)
 
     layer <- rep(seq_len(length(result)),
@@ -64,10 +75,13 @@ lsm_l_ent.RasterStack <- function(landscape, base = "log2") {
 
 #' @name lsm_l_ent
 #' @export
-lsm_l_ent.RasterBrick <- function(landscape, base = "log2") {
+lsm_l_ent.RasterBrick <- function(landscape,
+                                  neighbourhood = 4,
+                                  base = "log2") {
 
     result <- lapply(X = raster::as.list(landscape),
                      FUN = lsm_l_ent_calc,
+                     neighbourhood = neighbourhood,
                      base = base)
 
     layer <- rep(seq_len(length(result)),
@@ -80,12 +94,15 @@ lsm_l_ent.RasterBrick <- function(landscape, base = "log2") {
 
 #' @name lsm_l_ent
 #' @export
-lsm_l_ent.stars <- function(landscape, base = "log2") {
+lsm_l_ent.stars <- function(landscape,
+                            neighbourhood = 4,
+                            base = "log2") {
 
     landscape <- methods::as(landscape, "Raster")
 
     result <- lapply(X = raster::as.list(landscape),
                      FUN = lsm_l_ent_calc,
+                     neighbourhood = neighbourhood,
                      base = base)
 
     layer <- rep(seq_len(length(result)),
@@ -98,10 +115,13 @@ lsm_l_ent.stars <- function(landscape, base = "log2") {
 
 #' @name lsm_l_ent
 #' @export
-lsm_l_ent.list <- function(landscape, base = "log2") {
+lsm_l_ent.list <- function(landscape,
+                           neighbourhood = 4,
+                           base = "log2") {
 
     result <- lapply(X = landscape,
                      FUN = lsm_l_ent_calc,
+                     neighbourhood = neighbourhood,
                      base = base)
 
     layer <- rep(seq_len(length(result)),
@@ -112,16 +132,18 @@ lsm_l_ent.list <- function(landscape, base = "log2") {
     tibble::add_column(result, layer, .before = TRUE)
 }
 
-lsm_l_ent_calc <- function(landscape, base){
+lsm_l_ent_calc <- function(landscape, neighbourhood, base){
 
     # convert to matrix
     if(class(landscape) != "matrix") {
         landscape <- raster::as.matrix(landscape)
     }
 
-    cmh  <- rcpp_get_composition_vector(landscape)
+    com <- rcpp_get_coocurrence_matrix(landscape,
+                                       directions = as.matrix(neighbourhood))
+    com_c <- colSums(com)
 
-    comp <- rcpp_get_entropy(cmh, base)
+    comp <- rcpp_get_entropy(com_c, base)
 
     tibble::tibble(
         level = "landscape",

--- a/R/lsm_l_mutinf.R
+++ b/R/lsm_l_mutinf.R
@@ -153,13 +153,15 @@ lsm_l_mutinf_calc <- function(landscape, neighbourhood, ordered, base){
         landscape <- raster::as.matrix(landscape)
     }
 
-    cmh  <- rcpp_get_composition_vector(landscape)
+    com <- rcpp_get_coocurrence_matrix(landscape,
+                                       directions = as.matrix(neighbourhood))
+    com_c <- colSums(com)
 
     coh <- rcpp_get_coocurrence_vector(landscape,
                                        directions = as.matrix(neighbourhood),
                                        ordered = ordered)
 
-    comp <- rcpp_get_entropy(cmh, base)
+    comp <- rcpp_get_entropy(com_c, base)
     cplx <- rcpp_get_entropy(coh, base)
     conf <- cplx - comp
     aggr <- comp - conf

--- a/man/extract_lsm.Rd
+++ b/man/extract_lsm.Rd
@@ -40,7 +40,7 @@ extract_lsm(landscape, y, what, metric, name, type, directions,
 \arguments{
 \item{landscape}{Raster* Layer, Stack, Brick or a list of rasterLayers.}
 
-\item{y}{Spatial object ( Spatialy*; SpatialPolygons*; SpatialLines; Extent or sf equivalents); two-column matrix/data.frame/tibble or cellnumbers that are used to extract landscapemetrics.}
+\item{y}{Spatial object (Spatial*; SpatialPolygons*; SpatialLines; Extent or sf equivalents); two-column matrix/data.frame/tibble or cellnumbers that are used to extract landscapemetrics.}
 
 \item{what}{String indicating what metric to calculate, either "patch" (default) for all patch level metrics or any of the patch metrics functions.}
 

--- a/man/lsm_l_ent.Rd
+++ b/man/lsm_l_ent.Rd
@@ -9,20 +9,26 @@
 \alias{lsm_l_ent.list}
 \title{ENT (landscape level)}
 \usage{
-lsm_l_ent(landscape, base = "log2")
+lsm_l_ent(landscape, neighbourhood, base)
 
-\method{lsm_l_ent}{RasterLayer}(landscape, base = "log2")
+\method{lsm_l_ent}{RasterLayer}(landscape, neighbourhood = 4,
+  base = "log2")
 
-\method{lsm_l_ent}{RasterStack}(landscape, base = "log2")
+\method{lsm_l_ent}{RasterStack}(landscape, neighbourhood = 4,
+  base = "log2")
 
-\method{lsm_l_ent}{RasterBrick}(landscape, base = "log2")
+\method{lsm_l_ent}{RasterBrick}(landscape, neighbourhood = 4,
+  base = "log2")
 
-\method{lsm_l_ent}{stars}(landscape, base = "log2")
+\method{lsm_l_ent}{stars}(landscape, neighbourhood = 4, base = "log2")
 
-\method{lsm_l_ent}{list}(landscape, base = "log2")
+\method{lsm_l_ent}{list}(landscape, neighbourhood = 4, base = "log2")
 }
 \arguments{
 \item{landscape}{Raster* Layer, Stack, Brick or a list of rasterLayers.}
+
+\item{neighbourhood}{The number of directions in which cell adjacencies are considered as neighbours:
+4 (rook's case) or 8 (queen's case). The default is 4.}
 
 \item{base}{The unit in which entropy is measured.
 The default is "log2", which compute entropy in "bits".
@@ -32,7 +38,8 @@ The default is "log2", which compute entropy in "bits".
 tibble
 }
 \description{
-Shannon entropy
+A metric of a compositional complexity of a pattern (a pattern
+diversity)
 }
 \details{
 It measures a diversity (thematic complexity) of landscape classes.


### PR DESCRIPTION
…)` and `lsm_l_mutinf()`

(Explanation: Variable x is a color of a cell and y is a color of the cell but located just next to the focus cell. When you calculate H(z) from the histogram of all cells in the landscape (SHDI), z is not exactly the same as x or y. The way to do it consistently is to calculate H(x) and H(y) as entropies of marginal distributions x and y calculated from the co-occurrence matrix.)