### PR TITLE
removes intermediate cooc_mat

### DIFF
--- a/src/rcpp_get_coocurrence_matrix.cpp
+++ b/src/rcpp_get_coocurrence_matrix.cpp
@@ -14,7 +14,7 @@ IntegerMatrix rcpp_get_coocurrence_matrix(const IntegerMatrix x,
     std::map<int, unsigned> class_index = get_class_index_map(classes);
 
     unsigned n_classes = class_index.size();
-    IntegerMatrix result(n_classes, n_classes);
+    IntegerMatrix cooc_mat(n_classes, n_classes);
 
     // create neighbors coordinates
     IntegerMatrix tmp = rcpp_create_neighborhood(directions);
@@ -46,7 +46,7 @@ IntegerMatrix rcpp_get_coocurrence_matrix(const IntegerMatrix x,
                     if (tmp == na)
                         continue;
                     unsigned neig_class = class_index[tmp];
-                    result(focal_class,neig_class)++;
+                    cooc_mat(focal_class,neig_class)++;
                 }
             }
         }
@@ -54,8 +54,8 @@ IntegerMatrix rcpp_get_coocurrence_matrix(const IntegerMatrix x,
 
     // add names
     List u_names = List::create(classes, classes);
-    result.attr("dimnames") = u_names;
-    return result;
+    cooc_mat.attr("dimnames") = u_names;
+    return cooc_mat;
 }
 
 /*** R

--- a/src/rcpp_get_coocurrence_matrix.cpp
+++ b/src/rcpp_get_coocurrence_matrix.cpp
@@ -14,8 +14,7 @@ IntegerMatrix rcpp_get_coocurrence_matrix(const IntegerMatrix x,
     std::map<int, unsigned> class_index = get_class_index_map(classes);
 
     unsigned n_classes = class_index.size();
-    std::vector<std::vector<unsigned> > cooc_mat(n_classes,
-                                                 std::vector<unsigned>(n_classes));
+    IntegerMatrix result(n_classes, n_classes);
 
     // create neighbors coordinates
     IntegerMatrix tmp = rcpp_create_neighborhood(directions);
@@ -47,16 +46,9 @@ IntegerMatrix rcpp_get_coocurrence_matrix(const IntegerMatrix x,
                     if (tmp == na)
                         continue;
                     unsigned neig_class = class_index[tmp];
-                    cooc_mat[focal_class][neig_class]++;
+                    result(focal_class,neig_class)++;
                 }
             }
-        }
-    }
-
-    IntegerMatrix result(n_classes, n_classes);
-    for (unsigned col = 0; col < cooc_mat.size(); col++) {
-        for (unsigned row = 0; row < cooc_mat[col].size(); row++) {
-            result(col, row) = cooc_mat[col][row];
         }
     }
 


### PR DESCRIPTION
I've been working on some c++ code and found out that we are creating a new `cooc_mat` object and after some calculations, we are copying the same object to the `result` object. 
I removed this intermediate object - the results are the same, calculation time is also very similar (faster by tens of second); however, we now have ten lines of code less. 

Please take a look and merge the pull request if you think this is a good idea.