### PR TITLE
:zap: `window_lsm()` can handle class-level metrics #211 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,6 +78,6 @@ ByteCompile: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 SystemRequirements: C++11
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
     ggplot2,
     methods,
     raster,
+    terra,
     Rcpp,
     sp,
     stats,
@@ -66,7 +67,6 @@ Suggests:
     knitr,
     rgeos,
     rmarkdown,
-    terra,
     testthat
 Enhances:
     stars, 

--- a/R/get_boundaries.R
+++ b/R/get_boundaries.R
@@ -2,7 +2,7 @@
 #'
 #' @description Get boundary cells of patches
 #'
-#' @param landscape RasterLayer or matrix.
+#' @param landscape SpatRaster, RasterLayer or matrix.
 #' @param consider_boundary Logical if cells that only neighbour the landscape
 #' boundary should be considered as edge.
 #' @param edge_depth Distance (in cells) a cell has the be away from the patch
@@ -17,7 +17,7 @@
 #' cell or a cell with a different value than itself. Non-boundary cells only
 #' neighbour cells with the same value than themself.
 #'
-#' @return List with RasterLayer or matrix
+#' @return List with SpatRaster, RasterLayer or matrix
 #'
 #' @examples
 #' class_1 <- get_patches(landscape, class = 1)[[1]]
@@ -36,12 +36,19 @@ get_boundaries <- function(landscape,
     landscape <- landscape_as_list(landscape)
 
     result <- lapply(X = landscape, function(x) {
-
-        result_temp <- get_boundaries_calc(raster::as.matrix(x),
-                                           consider_boundary = consider_boundary,
-                                           edge_depth = edge_depth,
-                                           as_NA = as_NA,
-                                           patch_id = patch_id)
+        if (inherits(x = x, what = "RasterLayer")) {
+            result_temp <- get_boundaries_calc(raster::as.matrix(x),
+                                               consider_boundary = consider_boundary,
+                                               edge_depth = edge_depth,
+                                               as_NA = as_NA,
+                                               patch_id = patch_id)
+        } else if (inherits(x = x, what = "SpatRaster")) {
+            result_temp <- get_boundaries_calc(terra::as.matrix(x, wide = TRUE),
+                                               consider_boundary = consider_boundary,
+                                               edge_depth = edge_depth,
+                                               as_NA = as_NA,
+                                               patch_id = patch_id)
+        }
 
         # convert back to raster
         if (return_raster && !inherits(x = x, what = "matrix")) {
@@ -115,8 +122,8 @@ get_boundaries_calc <- function(landscape,
         present_classes <- get_unique_values_int(landscape, verbose = FALSE)
 
         if (any(present_classes == 0)) {
-           warning("Not able to use original patch id because at least one id equals zero.",
-                   call. = FALSE)
+            warning("Not able to use original patch id because at least one id equals zero.",
+                    call. = FALSE)
         }
 
         # relabel edge cells (value = 1) with original patch id

--- a/R/get_patches.R
+++ b/R/get_patches.R
@@ -86,9 +86,13 @@ get_patches_int <- function(landscape, class, directions,
     # convert to matrix
     if (!inherits(x = landscape, what = "matrix")) {
 
-        landscape_mat <- raster::as.matrix(landscape)
+        if (inherits(x = landscape, what = "RasterLayer")) {
+            landscape_mat <- raster::as.matrix(landscape)
+        } else if (inherits(x = landscape, what = "SpatRaster")) {
+            landscape_mat <- terra::as.matrix(landscape, wide = TRUE)
+        }
 
-    # already a matrix
+        # already a matrix
     } else {
 
         landscape_mat <- landscape
@@ -143,7 +147,7 @@ get_patches_int <- function(landscape, class, directions,
 
             rcpp_ccl(landscape_temp, 4)
 
-        # connected labeling with 8 neighbours
+            # connected labeling with 8 neighbours
         } else if (directions == 8) {
 
             rcpp_ccl(landscape_temp, 8)
@@ -160,7 +164,7 @@ get_patches_int <- function(landscape, class, directions,
         if (return_raster) {
 
             landscape_temp <- matrix_to_raster(matrix = landscape_temp,
-                                                landscape = landscape, to_disk = to_disk)
+                                               landscape = landscape, to_disk = to_disk)
         }
 
         patch_landscape[[i]] <- landscape_temp

--- a/R/get_unique_values.R
+++ b/R/get_unique_values.R
@@ -2,7 +2,7 @@
 #'
 #' @description This function returns the unique values of an object.
 #'
-#' @param x Vector, matrix, raster, stars, or terra object or list of previous.
+#' @param x Vector, matrix, raster, stars, or SpatRaster (terra) object or list of previous.
 #' @param simplify If true, a vector will be returned instead of a list for
 #' 1-dimensional input
 #' @param verbose If true, warning messages are printend
@@ -59,6 +59,9 @@ get_unique_values_int <- function(landscape, verbose) {
     if (inherits(x = landscape, what = "RasterLayer")) {
 
         landscape <- raster::as.matrix(landscape)
+
+    } else if (inherits(x = landscape, what = "SpatRaster")) {
+        landscape <- terra::as.matrix(landscape, wide = TRUE)
 
     } else if (!inherits(x = landscape, what = "matrix") &&
                !inherits(x = landscape, what = "integer") &&

--- a/R/landscape_as_list.R
+++ b/R/landscape_as_list.R
@@ -2,7 +2,7 @@
 #'
 #' @description Convert raster input to list
 #'
-#' @param landscape Raster* Layer, Stack, Brick, Stars or a list of rasterLayers
+#' @param landscape SpatRaster, Raster* Layer, Stack, Brick, Stars or a list of rasterLayers
 #'
 #' @details Mainly for internal use
 #'
@@ -59,9 +59,9 @@ landscape_as_list.stars <- function(landscape) {
 #' @export
 landscape_as_list.SpatRaster <- function(landscape) {
 
-    landscape <- methods::as(landscape, "Raster")
+    landscape <- methods::as(landscape, "SpatRaster")
 
-    landscape <- raster::as.list(landscape)
+    landscape <- terra::as.list(landscape)
 
     return(landscape)
 }

--- a/R/raster_to_points.R
+++ b/R/raster_to_points.R
@@ -49,7 +49,11 @@ raster_to_points_internal <- function(landscape, return_NA) {
                                         cell = 1:raster::ncell(landscape))
 
     # add values including NA
-    xyz[, 3] <- raster::getValues(landscape)
+    if (inherits(x = landscape, what = "RasterLayer")) {
+        xyz[, 3] <- raster::getValues(landscape)
+    } else {
+        xyz[, 3] <- terra::values(landscape)
+    }
 
     if (!return_NA) {
         xyz <- xyz[!is.na(xyz[, 3]), ]

--- a/R/show_lsm.R
+++ b/R/show_lsm.R
@@ -95,9 +95,15 @@ show_lsm_internal <- function(landscape, what, class,
 
     if (any(class == "global")) {
 
-        patches_tibble <- raster::as.data.frame(sum(raster::stack(landscape_labeled),
-                                                    na.rm = TRUE),
-                                                xy = TRUE)
+        if (inherits(x = landscape_labeled[[1]], what = "RasterLayer")) {
+            patches_tibble <- raster::as.data.frame(sum(raster::stack(landscape_labeled),
+                                                        na.rm = TRUE),
+                                                    xy = TRUE)
+        } else {
+            patches_tibble <- terra::as.data.frame(sum(terra::rast(landscape_labeled),
+                                                       na.rm = TRUE),
+                                                   xy = TRUE, na.rm = FALSE)
+        }
 
         names(patches_tibble) <- c("x", "y", "id")
 
@@ -127,7 +133,11 @@ show_lsm_internal <- function(landscape, what, class,
 
         patches_tibble <- lapply(X = seq_along(landscape_labeled), FUN = function(i){
             names(landscape_labeled[[i]]) <- "id"
-            x <- raster::as.data.frame(landscape_labeled[[i]], xy = TRUE)
+            if (inherits(x = landscape_labeled[[i]], what = "RasterLayer")) {
+                x <- raster::as.data.frame(landscape_labeled[[i]], xy = TRUE)
+            } else {
+                x <- terra::as.data.frame(landscape_labeled[[i]], xy = TRUE, na.rm = FALSE)
+            }
             x$class <- names(landscape_labeled[i])
             return(x)}
         )

--- a/R/show_patches.R
+++ b/R/show_patches.R
@@ -57,9 +57,14 @@ show_patches_internal <- function(landscape, class, directions, labels, nrow, nc
 
     if (any(class == "global")) {
 
-        patches_tibble <- raster::as.data.frame(sum(raster::stack(landscape_labeled),
-                                                    na.rm = TRUE),
-                                                xy = TRUE)
+        if (inherits(x = landscape_labeled[[1]], what = "RasterLayer")) {
+            patches_tibble <- raster::as.data.frame(sum(raster::stack(landscape_labeled),
+                                                        na.rm = TRUE),
+                                                    xy = TRUE)
+        } else {
+            patches_tibble <- terra::as.data.frame(sum(terra::rast(landscape_labeled), na.rm = TRUE),
+                                                   xy = TRUE, na.rm = FALSE)
+        }
 
         names(patches_tibble) <- c("x", "y", "value")
 

--- a/R/window_lsm.R
+++ b/R/window_lsm.R
@@ -3,7 +3,8 @@
 #' @description Moving window
 #'
 #' @param landscape Raster* Layer, Stack, Brick, SpatRaster (terra), stars, or a list of rasterLayers.
-#' @param window Moving window matrix.
+#' @param window Moving window matrix. The window can be defined as one (for a square) or two numbers (row, col);
+#' or with an odd-sized weights matrix. For details see \code{?terra::focal}
 #' @param level Level of metrics. Either 'patch', 'class' or 'landscape' (or vector with combination).
 #' @param metric Abbreviation of metrics (e.g. 'area').
 #' @param name Full name of metrics (e.g. 'core area')
@@ -11,14 +12,18 @@
 #' @param what Selected level of metrics: either "patch", "class" or "landscape".
 #' It is also possible to specify functions as a vector of strings, e.g. `what = c("lsm_c_ca", "lsm_l_ta")`.
 #' @param progress Print progress report.
+#' @param na_policy Determines the behaviour for focal NA cells.
+#' Either "all" (compute for all cells), "only" (only for cells that are NA) or
+#' "omit" (skip cells that are NA). Use na.rm=TRUE to ignore cells that are NA around a focal cell.
+#' For details see \code{?terra::focal}
 #' @param ... Arguments passed on to \code{calculate_lsm()}.
 #'
 #' @details
 #' The function calculates for each focal cell the selected landscape metrics (currently only landscape level
 #' metrics are allowed) for a local neighbourhood. The neighbourhood can be specified using a matrix. For more
-#' details, see \code{?raster::focal()}. The result will be a \code{RasterLayer} in which each focal cell includes
+#' details, see \code{?terra::focal()} and \code{terra::focalMat()}. The result will be a \code{SpatRaster} in which each focal cell includes
 #' the value of its neighbourhood and thereby allows to show gradients and variability in the landscape (Hagen-Zanker 2016).
-#' To be type stable, the acutally result is always a nested list (first level for \code{RasterStack} layers, second level
+#' To be type stable, the result is always a nested list (first level for \code{SpatRaster} layers, second level
 #' for selected landscape metrics).
 #'
 #' @seealso
@@ -53,16 +58,21 @@
 #'
 #' @export
 window_lsm <- function(landscape,
-                            window,
-                            level = "landscape",
-                            metric = NULL,
-                            name = NULL,
-                            type = NULL,
-                            what = NULL,
-                            progress = FALSE,
-                            ...) {
+                       window,
+                       level = "landscape",
+                       metric = NULL,
+                       name = NULL,
+                       type = NULL,
+                       what = NULL,
+                       progress = FALSE,
+                       na_policy = "all",
+                       ...) {
 
-    landscape <- landscape_as_list(landscape)
+    if (inherits(x = landscape, what = "list")) {
+        landscape <- lapply(landscape, function(x) {terra::rast(x)})
+    } else {
+        landscape <- landscape |> terra::rast() |> landscape_as_list()
+    }
 
     result <- lapply(X = seq_along(landscape), FUN = function(x) {
 
@@ -79,6 +89,7 @@ window_lsm <- function(landscape,
                        type = type,
                        what = what,
                        progress = FALSE,
+                       na_policy = na_policy,
                        ...)
     })
 
@@ -97,6 +108,7 @@ window_lsm_int <- function(landscape,
                            type,
                            what,
                            progress,
+                           na_policy,
                            ...) {
 
     # check if window has uneven sides
@@ -127,11 +139,16 @@ window_lsm_int <- function(landscape,
     points <- raster_to_points(landscape)[, 2:4]
 
     # resolution of original raster
-    resolution <- raster::res(landscape)
+    resolution <- terra::res(landscape)
 
     # get dimensions of window
-    n_row = nrow(window)
-    n_col = ncol(window)
+    if (is.null(dim(window))) {
+        n_row = window
+        n_col = window
+    } else {
+        n_row = terra::nrow(window)
+        n_col = terra::ncol(window)
+    }
 
     # create object for warning messages
     warning_messages <- character(0)
@@ -144,7 +161,7 @@ window_lsm_int <- function(landscape,
             cat("\r> Progress metrics: ", current_metric, "/", number_metrics)
         }
 
-        raster::focal(x = landscape, w = window, fun = function(x) {
+        terra::focal(x = landscape, w = window, fun = function(x) {
 
             calculate_lsm_focal(landscape = x,
                                 n_row = n_row,
@@ -153,13 +170,13 @@ window_lsm_int <- function(landscape,
                                 points = points,
                                 what = metrics_list[[current_metric]],
                                 ...)},
-            pad = TRUE, padValue = NA)
-        })},
-        warning = function(cond) {
+            na.policy = na_policy, fillvalue = NA)
+    })},
+    warning = function(cond) {
 
-            warning_messages <<- c(warning_messages, conditionMessage(cond))
+        warning_messages <<- c(warning_messages, conditionMessage(cond))
 
-            invokeRestart("muffleWarning")})
+        invokeRestart("muffleWarning")})
 
     names(result) <- metrics_list
 
@@ -232,9 +249,13 @@ calculate_lsm_focal <- function(landscape,
     arguments_values$landscape <- raster_window
 
     # run function
-    result <- do.call(what = foo,
-                      args = arguments_values)
+    x <- do.call(what = foo,
+                 args = arguments_values)
+    result <- x$value
+    if (!anyNA(x$class)) {
+        names(result) <- paste("class:",x$class)
+    }
 
-    return(result$value)
+    return(result)
 }
 

--- a/man/get_boundaries.Rd
+++ b/man/get_boundaries.Rd
@@ -14,7 +14,7 @@ get_boundaries(
 )
 }
 \arguments{
-\item{landscape}{RasterLayer or matrix.}
+\item{landscape}{SpatRaster, RasterLayer or matrix.}
 
 \item{consider_boundary}{Logical if cells that only neighbour the landscape
 boundary should be considered as edge.}
@@ -29,7 +29,7 @@ edge to be considered as core cell.}
 \item{return_raster}{If false, matrix is returned.}
 }
 \value{
-List with RasterLayer or matrix
+List with SpatRaster, RasterLayer or matrix
 }
 \description{
 Get boundary cells of patches

--- a/man/get_unique_values.Rd
+++ b/man/get_unique_values.Rd
@@ -7,7 +7,7 @@
 get_unique_values(x, simplify = FALSE, verbose = TRUE)
 }
 \arguments{
-\item{x}{Vector, matrix, raster, stars, or terra object or list of previous.}
+\item{x}{Vector, matrix, raster, stars, or SpatRaster (terra) object or list of previous.}
 
 \item{simplify}{If true, a vector will be returned instead of a list for
 1-dimensional input}

--- a/man/landscape_as_list.Rd
+++ b/man/landscape_as_list.Rd
@@ -31,7 +31,7 @@ landscape_as_list(landscape)
 \method{landscape_as_list}{numeric}(landscape)
 }
 \arguments{
-\item{landscape}{Raster* Layer, Stack, Brick, Stars or a list of rasterLayers}
+\item{landscape}{SpatRaster, Raster* Layer, Stack, Brick, Stars or a list of rasterLayers}
 }
 \value{
 list

--- a/man/lsm_c_contig_cv.Rd
+++ b/man/lsm_c_contig_cv.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_CV is a 'Shape metric'. It summarises each class as the mean of each patch
 belonging to class i. CONTIG_CV asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_c_contig_mn.Rd
+++ b/man/lsm_c_contig_mn.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_MN is a 'Shape metric'. It summarises each class as the mean of each patch
 belonging to class i. CONTIG_MN asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_c_contig_sd.Rd
+++ b/man/lsm_c_contig_sd.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_SD is a 'Shape metric'. It summarises each class as the mean of each patch
 belonging to class i. CONTIG_SD asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_c_te.Rd
+++ b/man/lsm_c_te.Rd
@@ -27,7 +27,7 @@ TE is an 'Area and edge metric'. Total (class) edge includes all edges between c
 all other classes k. It measures the configuration of the landscape because a highly
 fragmented landscape will have many edges. However, total edge is an absolute measure,
 making comparisons among landscapes with different total areas difficult. If
-\code{cound_boundary = TRUE} also edges to the landscape boundary are included.
+\code{count_boundary = TRUE} also edges to the landscape boundary are included.
 
 \subsection{Units}{Meters}
 \subsection{Range}{TE >= 0}

--- a/man/lsm_l_contig_cv.Rd
+++ b/man/lsm_l_contig_cv.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_CV is a 'Shape metric'. It summarises the landscape as the coefficient of variation of all patches
 in the landscape. CONTIG_CV asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_l_contig_mn.Rd
+++ b/man/lsm_l_contig_mn.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_MN is a 'Shape metric'. It summarises the landscape as the mean of all patches
 in the landscape. CONTIG_MN asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_l_contig_sd.Rd
+++ b/man/lsm_l_contig_sd.Rd
@@ -25,10 +25,12 @@ where \eqn{CONTIG[patch_{ij}]} is the contiguity of each patch.
 CONTIG_SD is a 'Shape metric'. It summarises the landscape as the standard deviation of all patches
 in the landscape. CONTIG_SD asses the spatial connectedness (contiguity) of
 cells in patches. The metric coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/lsm_l_te.Rd
+++ b/man/lsm_l_te.Rd
@@ -23,7 +23,7 @@ where \eqn{e_{ik}} is the edge lengths in meters.
 TE is an 'Area and edge metric'. Total edge includes all edges. It measures the
 configuration of the landscape because a highly fragmented landscape will have many
 edges. However, total edge is an absolute measure, making comparisons among landscapes
-with different total areas difficult. If \code{cound_boundary = TRUE} also edges to the
+with different total areas difficult. If \code{count_boundary = TRUE} also edges to the
 landscape boundary are included.
 
 \subsection{Units}{Meters}

--- a/man/lsm_p_contig.Rd
+++ b/man/lsm_p_contig.Rd
@@ -27,10 +27,12 @@ the size of the filter matrix (13 in this case).
 
 CONTIG is a 'Shape metric'. It asses the spatial connectedness (contiguity) of
 cells in patches. CONTIG coerces patch values to a value of 1 and the background
-to NA. A nine cell focal filter matrix:\preformatted{filter_matrix <- matrix(c(1, 2, 1,
+to NA. A nine cell focal filter matrix:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{filter_matrix <- matrix(c(1, 2, 1,
                           2, 1, 2,
                           1, 2, 1), 3, 3, byrow = T)
-}
+}\if{html}{\out{</div>}}
 
 ... is then used to weight orthogonally contiguous pixels more heavily than
 diagonally contiguous pixels. Therefore, larger and more connections between

--- a/man/matrix_to_raster.Rd
+++ b/man/matrix_to_raster.Rd
@@ -17,7 +17,7 @@ matrix_to_raster(
 \arguments{
 \item{matrix}{matrix with values.}
 
-\item{landscape}{RasterLayer.}
+\item{landscape}{RasterLayer or SpatRaster}
 
 \item{landscape_empty}{If true, RasterLayer is landscape_empty}
 

--- a/man/show_cores.Rd
+++ b/man/show_cores.Rd
@@ -16,7 +16,7 @@ show_cores(
 )
 }
 \arguments{
-\item{landscape}{Raster object}
+\item{landscape}{Raster or SpatRaster object}
 
 \item{directions}{The number of directions in which patches should be
 connected: 4 (rook's case) or 8 (queen's case).}

--- a/man/window_lsm.Rd
+++ b/man/window_lsm.Rd
@@ -13,13 +13,15 @@ window_lsm(
   type = NULL,
   what = NULL,
   progress = FALSE,
+  na_policy = "all",
   ...
 )
 }
 \arguments{
 \item{landscape}{Raster* Layer, Stack, Brick, SpatRaster (terra), stars, or a list of rasterLayers.}
 
-\item{window}{Moving window matrix.}
+\item{window}{Moving window matrix. The window can be defined as one (for a square) or two numbers (row, col);
+or with an odd-sized weights matrix. For details see \code{?terra::focal}}
 
 \item{level}{Level of metrics. Either 'patch', 'class' or 'landscape' (or vector with combination).}
 
@@ -34,6 +36,11 @@ It is also possible to specify functions as a vector of strings, e.g. \code{what
 
 \item{progress}{Print progress report.}
 
+\item{na_policy}{Determines the behaviour for focal NA cells.
+Either "all" (compute for all cells), "only" (only for cells that are NA) or
+"omit" (skip cells that are NA). Use na.rm=TRUE to ignore cells that are NA around a focal cell.
+For details see \code{?terra::focal}}
+
 \item{...}{Arguments passed on to \code{calculate_lsm()}.}
 }
 \value{
@@ -45,9 +52,9 @@ Moving window
 \details{
 The function calculates for each focal cell the selected landscape metrics (currently only landscape level
 metrics are allowed) for a local neighbourhood. The neighbourhood can be specified using a matrix. For more
-details, see \code{?raster::focal()}. The result will be a \code{RasterLayer} in which each focal cell includes
+details, see \code{?terra::focal()} and \code{terra::focalMat()}. The result will be a \code{SpatRaster} in which each focal cell includes
 the value of its neighbourhood and thereby allows to show gradients and variability in the landscape (Hagen-Zanker 2016).
-To be type stable, the acutally result is always a nested list (first level for \code{RasterStack} layers, second level
+To be type stable, the result is always a nested list (first level for \code{SpatRaster} layers, second level
 for selected landscape metrics).
 }
 \examples{

--- a/tests/testthat/test-sample-lsm.R
+++ b/tests/testthat/test-sample-lsm.R
@@ -65,14 +65,14 @@ test_that("sample_lsm works for polygons ", {
 
     expect_true(all("patch" %in% result_poly$level))
 
-    if (!nzchar(system.file(package = "rgeos"))) {
-
-        expect_warning(sample_lsm(landscape,
-                                  y = sample_plots, size = 5,
-                                  what = "lsm_p_area"),
-                       regexp = "Package 'rgeos' not installed. Please make sure polygons are disaggregated.",
-                       fixed = TRUE)
-    }
+    # if (!nzchar(system.file(package = "rgeos"))) {
+    #
+    #     expect_warning(sample_lsm(landscape,
+    #                               y = sample_plots, size = 5,
+    #                               what = "lsm_p_area"),
+    #                    regexp = "Package 'rgeos' not installed. Please make sure polygons are disaggregated.",
+    #                    fixed = TRUE)
+    # }
 })
 
 test_that("sample_lsm works for lines ", {

--- a/tests/testthat/test-window-lsm.R
+++ b/tests/testthat/test-window-lsm.R
@@ -33,6 +33,9 @@ test_that("window_lsm returns works for all data types", {
 
     expect_is(window_lsm(landscape_list, window = window, what = "lsm_l_pr"),
               class = "list")
+
+    expect_is(window_lsm(landscape_terra, window = window, what = "lsm_l_pr"),
+              class = "list")
 })
 
 test_that("window_lsm returns all errors", {

--- a/tests/testthat/test-window-lsm.R
+++ b/tests/testthat/test-window-lsm.R
@@ -41,7 +41,7 @@ test_that("window_lsm returns works for all data types", {
 test_that("window_lsm returns all errors", {
 
     expect_error(window_lsm(landscape, window = window, what = "lsm_p_area"),
-                 regexp = "'window_lsm()' is only able to calculate landscape level metrics.",
+                 regexp = "'window_lsm()' is not able to calculate patch level metrics.",
                  fixed = TRUE)
 
     expect_error(window_lsm(landscape, window = window_even, what = "lsm_l_pr"),


### PR DESCRIPTION
`window_lsm()` internally uses `terra::focal` instead of `raster::focal`, now. This required changes at many more places than expected, and since I feel still a bit rookie with `terra`, this PR needs a review.

