### PR TITLE
removes rgeos deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,13 +64,12 @@ Suggests:
     covr,
     dplyr,
     knitr,
-    rgeos,
     rmarkdown,
     terra,
     testthat
 Enhances:
-    stars, 
-    sf,
+    stars,
+    sf
 LinkingTo: 
     Rcpp,
     RcppArmadillo

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 * Bugfixes
     * SHEI now equals to 0 when only one patch present 
 * Various
-    * Fix typo in Maintainer name
+    * Fixes typo in Maintainer name
+    * Removes rgeos dependency
 
 # landscapemetrics 1.5.4
 * Improvements

--- a/R/extract_lsm.R
+++ b/R/extract_lsm.R
@@ -38,7 +38,7 @@
 #' extract_lsm(landscape, y = points_sp, what = "lsm_p_area")
 #'
 #' \dontrun{
-#' # use lines (works only if rgeos is installed)
+#' # use lines
 #' x1 <- c(1, 5, 15, 10)
 #' y1 <- c(1, 5, 15, 25)
 #'

--- a/R/sample_lsm.R
+++ b/R/sample_lsm.R
@@ -49,7 +49,7 @@
 #' sample_lsm(landscape, y = points_sp, size = 15, what = "lsm_l_np", return_raster = TRUE)
 #'
 #' \dontrun{
-#' # use lines (works only if rgeos is installed)
+#' # use lines
 #' x1 <- c(1, 5, 15, 10)
 #' y1 <- c(1, 5, 15, 25)
 #'
@@ -143,21 +143,7 @@ sample_lsm_int <- function(landscape,
 
             y <- sp::SpatialPolygons(y@polygons)
         }
-
-        # disaggregate if rgeos is installed
-        if (nzchar(system.file(package = "rgeos"))) {
-
-            y <- sp::disaggregate(y)
-
-        # warning that rgeos is not installed
-        } else {
-
-            if (verbose) {
-
-                warning("Package 'rgeos' is not installed. Please make sure polygons are disaggregated.",
-                        call. = FALSE)
-            }
-        }
+        y <- disaggregate_sp_tmp(y)
 
         # how many plots are present
         # number_plots <- length(y)
@@ -230,21 +216,11 @@ sample_lsm_int <- function(landscape,
 
                 y <- sp::SpatialLines(y@lines)
             }
+            # disaggregate lines
+            y <- disaggregate_sp_tmp(y)
 
-            # check if rgeos is installed
-            if (nzchar(system.file(package = "rgeos"))) {
-
-                # disaggregate lines
-                y <- sp::disaggregate(y)
-
-                # create buffer around lines
-                y <- raster::buffer(x = y,
-                                    width = size, dissolve = FALSE)
-
-            } else {
-                stop("To sample landscape metrics in buffers around lines, the package 'rgeos' must be installed.",
-                     call. = FALSE)
-            }
+            # create buffer around lines
+            y <- raster::buffer(x = y, width = size, dissolve = FALSE)
 
         } else {
 

--- a/R/tmp.R
+++ b/R/tmp.R
@@ -1,0 +1,9 @@
+disaggregate_sp_tmp = function(x){
+    if (requireNamespace("terra", quietly = TRUE)) {
+        x = methods::as(terra::disagg(terra::vect(x)), "Spatial")
+    } else {
+        warning("Package 'terra' is not installed. Please make sure polygons are disaggregated.", call. = FALSE)
+    }
+    return(x)
+}
+

--- a/codemeta.json
+++ b/codemeta.json
@@ -128,18 +128,6 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "rgeos",
-      "name": "rgeos",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=rgeos"
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "rmarkdown",
       "name": "rmarkdown",
       "provider": {
@@ -266,7 +254,7 @@
     },
     "SystemRequirements": "C++11"
   },
-  "fileSize": "1877.396KB",
+  "fileSize": "28226.929KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/man/extract_lsm.Rd
+++ b/man/extract_lsm.Rd
@@ -66,7 +66,7 @@ points_sp <- sp::SpatialPoints(points)
 extract_lsm(landscape, y = points_sp, what = "lsm_p_area")
 
 \dontrun{
-# use lines (works only if rgeos is installed)
+# use lines
 x1 <- c(1, 5, 15, 10)
 y1 <- c(1, 5, 15, 25)
 

--- a/man/sample_lsm.Rd
+++ b/man/sample_lsm.Rd
@@ -74,7 +74,7 @@ points_sp <- sp::SpatialPoints(sample_points)
 sample_lsm(landscape, y = points_sp, size = 15, what = "lsm_l_np", return_raster = TRUE)
 
 \dontrun{
-# use lines (works only if rgeos is installed)
+# use lines
 x1 <- c(1, 5, 15, 10)
 y1 <- c(1, 5, 15, 25)
 

--- a/tests/testthat/test-sample-lsm.R
+++ b/tests/testthat/test-sample-lsm.R
@@ -65,41 +65,19 @@ test_that("sample_lsm works for polygons ", {
 
     expect_true(all("patch" %in% result_poly$level))
 
-    if (!nzchar(system.file(package = "rgeos"))) {
-
-        expect_warning(sample_lsm(landscape,
-                                  y = sample_plots, size = 5,
-                                  what = "lsm_p_area"),
-                       regexp = "Package 'rgeos' not installed. Please make sure polygons are disaggregated.",
-                       fixed = TRUE)
-    }
 })
 
 test_that("sample_lsm works for lines ", {
 
-    if (!nzchar(system.file(package = "rgeos"))) {
+    result_lines <- sample_lsm(landscape,
+                               y = sample_lines,
+                               size = 5,
+                               level = "landscape",
+                               verbose = FALSE)
 
-        expect_error(sample_lsm(landscape,
-                                y = sample_lines,
-                                size = 5,
-                                level = "landscape"),
-                     regexp = "To sample landscape metrics in buffers around lines, the package 'rgeos' must be installed.",
-                     fixed = TRUE)
+    expect_is(object = result_lines, class = "tbl_df")
 
-    }
-
-    else {
-
-        result_lines <- sample_lsm(landscape,
-                                   y = sample_lines,
-                                   size = 5,
-                                   level = "landscape",
-                                   verbose = FALSE)
-
-        expect_is(object = result_lines, class = "tbl_df")
-
-        expect_true(all("landscape" %in% result_lines$level))
-    }
+    expect_true(all("landscape" %in% result_lines$level))
 })
 
 test_that("sample_lsm forwards arguments to calculate_lsm", {

--- a/vignettes/articles/guide_sample_lsm.Rmd
+++ b/vignettes/articles/guide_sample_lsm.Rmd
@@ -106,12 +106,10 @@ sample_lsm(landscape, y = points, size = 10,
            verbose = FALSE)
 ```
 
-It's also possible to construct buffers around lines, however, only if the [**rgeos**](https://cran.r-project.org/web/packages/rgeos/index.html) (Bivand & Rundel 2018) package is installed. Also, it's possibe to directly provide SpatialPolygons as sample plots.
+It's also possible to construct buffers around lines, and to directly provide SpatialPolygons as sample plots.
 
 ### References
 
 Pebesma, E., 2018. Simple Features for R: Standardized Support for Spatial Vector Data. The R Journal, https://journal.r-project.org/archive/2018/RJ-2018-009/
-
-Roger Bivand and Colin Rundel (2018). rgeos: Interface to Geometry Engine - Open Source ('GEOS'). R package version 0.4-2. https://CRAN.R-project.org/package=rgeos
 
 Roger S. Bivand, Edzer Pebesma, Virgilio Gomez-Rubio, 2013. Applied spatial data analysis with R, Second edition. Springer, NY. http://www.asdar-book.org/


### PR DESCRIPTION
@mhesselbarth -- this PR removes rgeos dependency using a temporary solution. This is important to make this change and push it to CRAN soon, as our current code (using rgeos) will stop working on CRAN in June (https://github.com/r-spatialecology/landscapemetrics/issues/273).