### PR TITLE
docs: update fragstats references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Authors@R: c(person("Maximilian H.K.", "Hesselbarth",
 Maintainer: Maximilian H.K. Hesselbarth <mhk.hesselbarth@gmail.com>
 Description: Calculates landscape metrics for categorical landscape patterns in 
     a tidy workflow. 'landscapemetrics' reimplements the most common metrics from
-    'FRAGSTATS' (<https://www.umass.edu/landeco/>) and new ones from the current 
+    'FRAGSTATS' (<https://www.fragstats.org/>) and new ones from the current 
     literature on landscape metrics. This package supports 'terra' SpatRaster objects 
     as input arguments. It further provides utility functionn to visualize patches, 
     select metrics and building blocks to develop new metrics.

--- a/R/calculate_lsm.R
+++ b/R/calculate_lsm.R
@@ -56,10 +56,9 @@
 #' @rdname calculate_lsm
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 calculate_lsm <- function(landscape,

--- a/R/landscapemetrics-package.R
+++ b/R/landscapemetrics-package.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' Calculates landscape metrics for categorical landscape patterns in a tidy workflow.
-#' 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.umass.edu/landeco/>)
+#' 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.fragstats.org/>)
 #' and adds new ones from the current literature on landscape metrics. This package
 #' supports 'terra' SpatRaster objects as input arguments. It further provides
 #' utility functions to visualize patches, select metrics and building blocks to

--- a/R/list_lsm.R
+++ b/R/list_lsm.R
@@ -34,10 +34,9 @@
 #' @rdname list_lsm
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 list_lsm <- function(level = NULL,

--- a/R/lsm_c_ai.R
+++ b/R/lsm_c_ai.R
@@ -32,10 +32,9 @@
 #' @rdname lsm_c_ai
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' He, H. S., DeZonia, B. E., & Mladenoff, D. J. 2000. An aggregation index (AI)
 #' to quantify spatial patterns of landscapes. Landscape ecology, 15(7), 591-601.

--- a/R/lsm_c_area_cv.R
+++ b/R/lsm_c_area_cv.R
@@ -37,10 +37,9 @@
 #' @rdname lsm_c_area_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_area_cv <- function(landscape, directions = 8) {

--- a/R/lsm_c_area_mn.R
+++ b/R/lsm_c_area_mn.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_c_area_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_area_mn <- function(landscape, directions = 8) {

--- a/R/lsm_c_area_sd.R
+++ b/R/lsm_c_area_sd.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_c_area_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_area_sd <- function(landscape, directions = 8) {

--- a/R/lsm_c_ca.R
+++ b/R/lsm_c_ca.R
@@ -38,10 +38,9 @@
 #' @rdname lsm_c_ca
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_ca <- function(landscape, directions = 8) {

--- a/R/lsm_c_cai_cv.R
+++ b/R/lsm_c_cai_cv.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_c_cai_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_cai_cv <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_cai_mn.R
+++ b/R/lsm_c_cai_mn.R
@@ -44,10 +44,9 @@
 #' @rdname lsm_c_cai_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_cai_mn <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_cai_sd.R
+++ b/R/lsm_c_cai_sd.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_c_cai_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_cai_sd <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_circle_cv.R
+++ b/R/lsm_c_circle_cv.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_circle_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_c_circle_mn.R
+++ b/R/lsm_c_circle_mn.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_circle_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_c_circle_sd.R
+++ b/R/lsm_c_circle_sd.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_circle_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_c_clumpy.R
+++ b/R/lsm_c_clumpy.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_c_clumpy
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_clumpy <- function(landscape) {

--- a/R/lsm_c_cohesion.R
+++ b/R/lsm_c_cohesion.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_c_cohesion
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Schumaker, N. H. 1996. Using landscape indices to predict habitat
 #' connectivity. Ecology, 77(4), 1210-1225.

--- a/R/lsm_c_contig_cv.R
+++ b/R/lsm_c_contig_cv.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_c_contig_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_c_contig_mn.R
+++ b/R/lsm_c_contig_mn.R
@@ -47,10 +47,9 @@
 #' @rdname lsm_c_contig_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_c_contig_sd.R
+++ b/R/lsm_c_contig_sd.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_c_contig_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_c_core_cv.R
+++ b/R/lsm_c_core_cv.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_c_core_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_core_cv <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_core_mn.R
+++ b/R/lsm_c_core_mn.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_core_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_core_mn <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_core_sd.R
+++ b/R/lsm_c_core_sd.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_core_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_core_sd <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_cpland.R
+++ b/R/lsm_c_cpland.R
@@ -38,10 +38,9 @@
 #' @rdname lsm_c_cpland
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_cpland <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_dcad.R
+++ b/R/lsm_c_dcad.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_dcad
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_dcad <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_dcore_cv.R
+++ b/R/lsm_c_dcore_cv.R
@@ -45,10 +45,9 @@
 #' @rdname lsm_c_dcore_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_dcore_cv <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_dcore_mn.R
+++ b/R/lsm_c_dcore_mn.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_c_dcore_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_dcore_mn <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_dcore_sd.R
+++ b/R/lsm_c_dcore_sd.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_c_dcore_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_dcore_sd <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_division.R
+++ b/R/lsm_c_division.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_c_division
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_c_ed.R
+++ b/R/lsm_c_ed.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_ed
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_ed <- function(landscape,

--- a/R/lsm_c_enn_cv.R
+++ b/R/lsm_c_enn_cv.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_c_enn_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_c_enn_mn.R
+++ b/R/lsm_c_enn_mn.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_enn_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_c_enn_sd.R
+++ b/R/lsm_c_enn_sd.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_enn_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_c_frac_cv.R
+++ b/R/lsm_c_frac_cv.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_frac_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_c_frac_mn.R
+++ b/R/lsm_c_frac_mn.R
@@ -38,10 +38,9 @@
 #' @rdname lsm_c_frac_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_c_frac_sd.R
+++ b/R/lsm_c_frac_sd.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_frac_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_c_gyrate_cv.R
+++ b/R/lsm_c_gyrate_cv.R
@@ -47,10 +47,9 @@
 #' @rdname lsm_c_gyrate_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_c_gyrate_mn.R
+++ b/R/lsm_c_gyrate_mn.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_c_gyrate_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_c_gyrate_sd.R
+++ b/R/lsm_c_gyrate_sd.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_c_gyrate_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_c_iji.R
+++ b/R/lsm_c_iji.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_c_iji
 #
 #' @references
-#'McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#'Program for Categorical and Continuous Maps. Computer software program produced by
-#'the authors at the University of Massachusetts, Amherst. Available at the following
-#'web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #'McGarigal, K., & Marks, B. J. 1995. FRAGSTATS: spatial pattern analysis
 #'program for quantifying landscape structure. Gen. Tech. Rep. PNW-GTR-351.

--- a/R/lsm_c_lpi.R
+++ b/R/lsm_c_lpi.R
@@ -35,10 +35,9 @@
 #' @rdname lsm_c_lpi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_lpi <- function(landscape, directions = 8) {

--- a/R/lsm_c_lsi.R
+++ b/R/lsm_c_lsi.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_c_lsi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_c_mesh.R
+++ b/R/lsm_c_mesh.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_c_mesh
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_c_ndca.R
+++ b/R/lsm_c_ndca.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_c_ndca
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_ndca <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_nlsi.R
+++ b/R/lsm_c_nlsi.R
@@ -37,10 +37,9 @@
 #' @rdname lsm_c_nlsi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_c_np.R
+++ b/R/lsm_c_np.R
@@ -31,10 +31,9 @@
 #' @rdname lsm_c_np
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_np <- function(landscape, directions = 8) {

--- a/R/lsm_c_pafrac.R
+++ b/R/lsm_c_pafrac.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_c_pafrac
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Burrough, P. A. 1986. Principles of Geographical Information Systems for
 #' Land Resources Assessment. Monographs on Soil and Resources Survey No. 12.

--- a/R/lsm_c_para_cv.R
+++ b/R/lsm_c_para_cv.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_c_para_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_para_cv <- function(landscape, directions = 8) {

--- a/R/lsm_c_para_mn.R
+++ b/R/lsm_c_para_mn.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_c_para_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_para_mn <- function(landscape, directions = 8) {

--- a/R/lsm_c_para_sd.R
+++ b/R/lsm_c_para_sd.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_c_para_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_para_sd <- function(landscape, directions = 8) {

--- a/R/lsm_c_pd.R
+++ b/R/lsm_c_pd.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_c_pd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_pd <- function(landscape, directions = 8) {

--- a/R/lsm_c_pladj.R
+++ b/R/lsm_c_pladj.R
@@ -29,10 +29,9 @@
 #' @rdname lsm_c_pladj
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/.
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org.
 #'
 #' @export
 lsm_c_pladj <- function(landscape) {

--- a/R/lsm_c_pland.R
+++ b/R/lsm_c_pland.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_c_pland
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_pland <- function(landscape, directions = 8) {

--- a/R/lsm_c_shape_cv.R
+++ b/R/lsm_c_shape_cv.R
@@ -38,10 +38,9 @@
 #' @rdname lsm_c_shape_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_c_shape_mn.R
+++ b/R/lsm_c_shape_mn.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_c_shape_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_c_shape_sd.R
+++ b/R/lsm_c_shape_sd.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_c_shape_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_c_split.R
+++ b/R/lsm_c_split.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_c_split
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_c_tca.R
+++ b/R/lsm_c_tca.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_c_tca
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_tca <- function(landscape, directions = 8, consider_boundary = FALSE, edge_depth = 1) {

--- a/R/lsm_c_te.R
+++ b/R/lsm_c_te.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_c_te
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_c_te <- function(landscape,

--- a/R/lsm_l_ai.R
+++ b/R/lsm_l_ai.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_l_ai
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' He, H. S., DeZonia, B. E., & Mladenoff, D. J. 2000. An aggregation index (AI)
 #' to quantify spatial patterns of landscapes. Landscape ecology, 15(7), 591-601.

--- a/R/lsm_l_area_cv.R
+++ b/R/lsm_l_area_cv.R
@@ -37,10 +37,9 @@
 #' @rdname lsm_l_area_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_area_cv <- function(landscape, directions = 8) {

--- a/R/lsm_l_area_mn.R
+++ b/R/lsm_l_area_mn.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_l_area_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_area_mn <- function(landscape, directions = 8) {

--- a/R/lsm_l_area_sd.R
+++ b/R/lsm_l_area_sd.R
@@ -37,10 +37,9 @@
 #' @rdname lsm_l_area_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_area_sd <- function(landscape, directions = 8) {

--- a/R/lsm_l_cai_cv.R
+++ b/R/lsm_l_cai_cv.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_l_cai_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_cai_cv <- function(landscape,

--- a/R/lsm_l_cai_mn.R
+++ b/R/lsm_l_cai_mn.R
@@ -44,10 +44,9 @@
 #' @rdname lsm_l_cai_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_cai_mn <- function(landscape,

--- a/R/lsm_l_cai_sd.R
+++ b/R/lsm_l_cai_sd.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_l_cai_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_cai_sd <- function(landscape,

--- a/R/lsm_l_circle_cv.R
+++ b/R/lsm_l_circle_cv.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_circle_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_l_circle_mn.R
+++ b/R/lsm_l_circle_mn.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_l_circle_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_l_circle_sd.R
+++ b/R/lsm_l_circle_sd.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_l_circle_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_l_cohesion.R
+++ b/R/lsm_l_cohesion.R
@@ -31,10 +31,9 @@
 #' @rdname lsm_l_cohesion
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Schumaker, N. H. 1996. Using landscape indices to predict habitat
 #' connectivity. Ecology, 77(4), 1210-1225.

--- a/R/lsm_l_contag.R
+++ b/R/lsm_l_contag.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_l_contag
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Riitters, K.H., O’Neill, R.V., Wickham, J.D. & Jones, K.B. (1996). A note on
 #' contagion indices for landscape analysis. Landscape ecology, 11, 197–202.

--- a/R/lsm_l_contig_cv.R
+++ b/R/lsm_l_contig_cv.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_l_contig_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_l_contig_mn.R
+++ b/R/lsm_l_contig_mn.R
@@ -47,10 +47,9 @@
 #' @rdname lsm_l_contig_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_l_contig_sd.R
+++ b/R/lsm_l_contig_sd.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_l_contig_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_l_core_cv.R
+++ b/R/lsm_l_core_cv.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_l_core_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_core_cv <- function(landscape,

--- a/R/lsm_l_core_mn.R
+++ b/R/lsm_l_core_mn.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_l_core_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_core_mn <- function(landscape,

--- a/R/lsm_l_core_sd.R
+++ b/R/lsm_l_core_sd.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_l_core_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_core_sd <- function(landscape,

--- a/R/lsm_l_dcad.R
+++ b/R/lsm_l_dcad.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_l_dcad
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_dcad <- function(landscape,

--- a/R/lsm_l_dcore_cv.R
+++ b/R/lsm_l_dcore_cv.R
@@ -45,10 +45,9 @@
 #' @rdname lsm_l_dcore_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_dcore_cv <- function(landscape,

--- a/R/lsm_l_dcore_mn.R
+++ b/R/lsm_l_dcore_mn.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_l_dcore_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_dcore_mn <- function(landscape,

--- a/R/lsm_l_dcore_sd.R
+++ b/R/lsm_l_dcore_sd.R
@@ -45,10 +45,9 @@
 #' @rdname lsm_l_dcore_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_dcore_sd <- function(landscape,

--- a/R/lsm_l_division.R
+++ b/R/lsm_l_division.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_l_division
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_l_ed.R
+++ b/R/lsm_l_ed.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_ed
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_ed <- function(landscape,

--- a/R/lsm_l_enn_cv.R
+++ b/R/lsm_l_enn_cv.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_l_enn_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_l_enn_mn.R
+++ b/R/lsm_l_enn_mn.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_l_enn_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_l_enn_sd.R
+++ b/R/lsm_l_enn_sd.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_l_enn_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_l_frac_cv.R
+++ b/R/lsm_l_frac_cv.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_frac_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_l_frac_mn.R
+++ b/R/lsm_l_frac_mn.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_frac_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_l_frac_sd.R
+++ b/R/lsm_l_frac_sd.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_frac_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_l_gyrate_cv.R
+++ b/R/lsm_l_gyrate_cv.R
@@ -47,10 +47,9 @@
 #' @rdname lsm_l_gyrate_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_l_gyrate_mn.R
+++ b/R/lsm_l_gyrate_mn.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_l_gyrate_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_l_gyrate_sd.R
+++ b/R/lsm_l_gyrate_sd.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_l_gyrate_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_l_iji.R
+++ b/R/lsm_l_iji.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_l_iji
 #
 #' @references
-#'McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#'Program for Categorical and Continuous Maps. Computer software program produced by
-#'the authors at the University of Massachusetts, Amherst. Available at the following
-#'web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #'McGarigal, K., & Marks, B. J. 1995. FRAGSTATS: spatial pattern analysis
 #'program for quantifying landscape structure. Gen. Tech. Rep. PNW-GTR-351.

--- a/R/lsm_l_lpi.R
+++ b/R/lsm_l_lpi.R
@@ -35,10 +35,9 @@
 #' @rdname lsm_l_lpi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_lpi <- function(landscape, directions = 8) {

--- a/R/lsm_l_lsi.R
+++ b/R/lsm_l_lsi.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_l_lsi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_l_mesh.R
+++ b/R/lsm_l_mesh.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_l_mesh
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_l_msidi.R
+++ b/R/lsm_l_msidi.R
@@ -30,10 +30,9 @@
 #' @rdname lsm_l_msidi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 #'

--- a/R/lsm_l_msiei.R
+++ b/R/lsm_l_msiei.R
@@ -30,10 +30,9 @@
 #' @rdname lsm_l_msiei
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 #'

--- a/R/lsm_l_ndca.R
+++ b/R/lsm_l_ndca.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_l_ndca
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_ndca <- function(landscape,

--- a/R/lsm_l_np.R
+++ b/R/lsm_l_np.R
@@ -32,10 +32,9 @@
 #' @rdname lsm_l_np
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_np <- function(landscape, directions = 8) {

--- a/R/lsm_l_pafrac.R
+++ b/R/lsm_l_pafrac.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_l_pafrac
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Burrough, P. A. 1986. Principles of Geographical Information Systems for
 #' Land Resources Assessment. Monographs on Soil and Resources Survey No. 12.

--- a/R/lsm_l_para_cv.R
+++ b/R/lsm_l_para_cv.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_l_para_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_para_cv <- function(landscape, directions = 8) {

--- a/R/lsm_l_para_mn.R
+++ b/R/lsm_l_para_mn.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_l_para_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_para_mn <- function(landscape, directions = 8) {

--- a/R/lsm_l_para_sd.R
+++ b/R/lsm_l_para_sd.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_l_para_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_para_sd <- function(landscape, directions = 8) {

--- a/R/lsm_l_pd.R
+++ b/R/lsm_l_pd.R
@@ -36,10 +36,9 @@
 #' @rdname lsm_l_pd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_pd <- function(landscape, directions = 8) {

--- a/R/lsm_l_pladj.R
+++ b/R/lsm_l_pladj.R
@@ -29,10 +29,9 @@
 #' @rdname lsm_l_pladj
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/.
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org.
 #'
 #' @export
 lsm_l_pladj <- function(landscape) {

--- a/R/lsm_l_pr.R
+++ b/R/lsm_l_pr.R
@@ -27,10 +27,9 @@
 #' @rdname lsm_l_pr
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_pr <- function(landscape){

--- a/R/lsm_l_prd.R
+++ b/R/lsm_l_prd.R
@@ -31,10 +31,9 @@
 #' @rdname lsm_l_prd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_prd <- function(landscape, directions = 8) {

--- a/R/lsm_l_rpr.R
+++ b/R/lsm_l_rpr.R
@@ -31,10 +31,9 @@
 #' @rdname lsm_l_rpr
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Romme, W. H. 1982. Fire and landscapediversity in subalpine forests of
 #' Yellowstone National Park.Ecol.Monogr. 52:199-221

--- a/R/lsm_l_shape_cv.R
+++ b/R/lsm_l_shape_cv.R
@@ -38,10 +38,9 @@
 #' @rdname lsm_l_shape_cv
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_l_shape_mn.R
+++ b/R/lsm_l_shape_mn.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_l_shape_mn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_l_shape_sd.R
+++ b/R/lsm_l_shape_sd.R
@@ -39,10 +39,9 @@
 #' @rdname lsm_l_shape_sd
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/lsm_l_shdi.R
+++ b/R/lsm_l_shdi.R
@@ -30,10 +30,9 @@
 #' @rdname lsm_l_shdi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Shannon, C., and W. Weaver. 1949. The mathematical theory of
 #' communication. Univ. IllinoisPress, Urbana

--- a/R/lsm_l_shei.R
+++ b/R/lsm_l_shei.R
@@ -32,10 +32,9 @@
 #' @rdname lsm_l_shei
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Shannon, C., and W. Weaver. 1949. The mathematical theory of
 #' communication. Univ. IllinoisPress, Urbana

--- a/R/lsm_l_sidi.R
+++ b/R/lsm_l_sidi.R
@@ -35,10 +35,9 @@
 #' @rdname lsm_l_sidi
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 #'

--- a/R/lsm_l_siei.R
+++ b/R/lsm_l_siei.R
@@ -35,10 +35,9 @@
 #' @rdname lsm_l_siei
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 #'

--- a/R/lsm_l_split.R
+++ b/R/lsm_l_split.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_l_split
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 #' size: new measures of landscape fragmentation.

--- a/R/lsm_l_ta.R
+++ b/R/lsm_l_ta.R
@@ -33,10 +33,9 @@
 #' @rdname lsm_l_ta
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_ta <- function(landscape, directions = 8) {

--- a/R/lsm_l_tca.R
+++ b/R/lsm_l_tca.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_l_tca
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_tca <- function(landscape,

--- a/R/lsm_l_te.R
+++ b/R/lsm_l_te.R
@@ -34,10 +34,9 @@
 #' @rdname lsm_l_te
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_l_te <- function(landscape, count_boundary = FALSE) {

--- a/R/lsm_p_area.R
+++ b/R/lsm_p_area.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_p_area
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_area <- function(landscape, directions = 8) {

--- a/R/lsm_p_cai.R
+++ b/R/lsm_p_cai.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_p_cai
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_cai <- function(landscape,

--- a/R/lsm_p_circle.R
+++ b/R/lsm_p_circle.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_p_circle
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 #' landscape structure using the GRASS geographical information system.

--- a/R/lsm_p_contig.R
+++ b/R/lsm_p_contig.R
@@ -49,10 +49,9 @@
 #' @rdname lsm_p_contig
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 #' Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/R/lsm_p_core.R
+++ b/R/lsm_p_core.R
@@ -46,10 +46,9 @@
 #' @rdname lsm_p_core
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_core <- function(landscape, directions = 8,

--- a/R/lsm_p_enn.R
+++ b/R/lsm_p_enn.R
@@ -42,10 +42,9 @@
 #' @rdname lsm_p_enn
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 #' structure and breeding birds in the Oregon Coast Range.

--- a/R/lsm_p_frac.R
+++ b/R/lsm_p_frac.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_p_frac
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 #' San Francisco. W. H. Freeman and Company.

--- a/R/lsm_p_gyrate.R
+++ b/R/lsm_p_gyrate.R
@@ -43,10 +43,9 @@
 #' @rdname lsm_p_gyrate
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 #' in fragmented landscapes. Conservation ecology, 1(1).

--- a/R/lsm_p_ncore.R
+++ b/R/lsm_p_ncore.R
@@ -48,10 +48,9 @@
 #' @rdname lsm_p_ncore
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_ncore <- function(landscape,

--- a/R/lsm_p_para.R
+++ b/R/lsm_p_para.R
@@ -41,10 +41,9 @@
 #' @rdname lsm_p_para
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_para <- function(landscape, directions = 8) {

--- a/R/lsm_p_perim.R
+++ b/R/lsm_p_perim.R
@@ -30,10 +30,9 @@
 #' @rdname lsm_p_perim
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 lsm_p_perim <- function(landscape, directions = 8) {

--- a/R/lsm_p_shape.R
+++ b/R/lsm_p_shape.R
@@ -40,10 +40,9 @@
 #' @rdname lsm_p_shape
 #'
 #' @references
-#' McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' web site: https://www.umass.edu/landeco/
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 #' Wildl. Soc.Bull. 3:171-173.

--- a/R/window_lsm.R
+++ b/R/window_lsm.R
@@ -51,10 +51,9 @@
 #' and its application to landscape pattern analysis. International journal of applied
 #' earth observation and geoinformation, 44, 205-216.
 #'
-#' McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-#' Program for Categorical and Continuous Maps. Computer software program produced by
-#' the authors at the University of Massachusetts, Amherst. Available at the following
-#' website: <https://www.umass.edu/landeco/>
+#' McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+#' Program for Categorical Maps. Computer software program produced by the authors;
+#' available at the following web site: https://www.fragstats.org
 #'
 #' @export
 window_lsm <- function(landscape,

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,7 +32,7 @@ README last updated: `r Sys.Date()`
 
 ## Overview
 
-**landscapemetrics** is a `R` package for calculating landscape metrics for categorical landscape patterns in a tidy workflow. The package can be used as a drop-in replacement for FRAGSTATS (McGarigal *et al.* 2012), as it offers a reproducible workflow for landscape analysis in a single environment. It also allows for calculations of four theoretical metrics of landscape complexity: a marginal entropy, a conditional entropy, a joint entropy, and a mutual information (Nowosad and Stepinski 2019).
+**landscapemetrics** is a `R` package for calculating landscape metrics for categorical landscape patterns in a tidy workflow. The package can be used as a drop-in replacement for FRAGSTATS (McGarigal *et al.* 2023), as it offers a reproducible workflow for landscape analysis in a single environment. It also allows for calculations of four theoretical metrics of landscape complexity: a marginal entropy, a conditional entropy, a joint entropy, and a mutual information (Nowosad and Stepinski 2019).
 
 **landscapemetrics** supports **terra**, and **stars** and takes `SpatRaster` or `stars` spatial objects as input arguments. Every function can be used in a piped workflow, as it always takes the data as the first argument and returns a `tibble`. 
 
@@ -142,6 +142,6 @@ Maintainers and contributors must follow this repository’s [CODE OF CONDUCT](C
 
 ### References
 
-McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following website: <https://www.umass.edu/landeco/>
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: <https://www.fragstats.org/>
 
 Nowosad J., TF Stepinski. 2019. Information theory as a consistent framework for quantification and classification of landscape patterns. https://doi.org/10.1007/s10980-019-00830-x

--- a/README.md
+++ b/README.md
@@ -212,11 +212,10 @@ CONDUCT](CODE_OF_CONDUCT.md).
 
 ### References
 
-McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial
-Pattern Analysis Program for Categorical and Continuous Maps. Computer
-software program produced by the authors at the University of
-Massachusetts, Amherst. Available at the following website:
-<https://www.umass.edu/landeco/>
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial 
+Pattern Analysis Program for Categorical Maps. Computer software 
+program produced by the authors; available at the following web 
+site: <https://www.fragstats.org>
 
 Nowosad J., TF Stepinski. 2019. Information theory as a consistent
 framework for quantification and classification of landscape patterns.

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "landscapemetrics",
-  "description": "Calculates landscape metrics for categorical landscape patterns in a tidy workflow. 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.fragstats.org/>) and new ones from the current literature on landscape metrics. This package supports 'terra' SpatRaster objects as input arguments. It further provides utility functionn to visualize patches, select metrics and building blocks to develop new metrics.",
+  "description": "Calculates landscape metrics for categorical landscape patterns in a tidy workflow. 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.umass.edu/landeco/>) and new ones from the current literature on landscape metrics. This package supports 'terra' SpatRaster objects as input arguments. It further provides utility functionn to visualize patches, select metrics and building blocks to develop new metrics.",
   "name": "landscapemetrics: Landscape Metrics for Categorical Map Patterns",
   "codeRepository": "https://r-spatialecology.github.io/landscapemetrics/",
   "issueTracker": "https://github.com/r-spatialecology/landscapemetrics/issues",

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "landscapemetrics",
-  "description": "Calculates landscape metrics for categorical landscape patterns in a tidy workflow. 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.umass.edu/landeco/>) and new ones from the current literature on landscape metrics. This package supports 'terra' SpatRaster objects as input arguments. It further provides utility functionn to visualize patches, select metrics and building blocks to develop new metrics.",
+  "description": "Calculates landscape metrics for categorical landscape patterns in a tidy workflow. 'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (<https://www.fragstats.org/>) and new ones from the current literature on landscape metrics. This package supports 'terra' SpatRaster objects as input arguments. It further provides utility functionn to visualize patches, select metrics and building blocks to develop new metrics.",
   "name": "landscapemetrics: Landscape Metrics for Categorical Map Patterns",
   "codeRepository": "https://r-spatialecology.github.io/landscapemetrics/",
   "issueTracker": "https://github.com/r-spatialecology/landscapemetrics/issues",

--- a/man/calculate_lsm.Rd
+++ b/man/calculate_lsm.Rd
@@ -96,10 +96,9 @@ type = "aggregation metric")
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{list_lsm}}

--- a/man/landscapemetrics.Rd
+++ b/man/landscapemetrics.Rd
@@ -7,7 +7,7 @@
 \title{landscapemetrics}
 \description{
 Calculates landscape metrics for categorical landscape patterns in a tidy workflow.
-'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (\url{https://www.umass.edu/landeco/})
+'landscapemetrics' reimplements the most common metrics from 'FRAGSTATS' (\url{https://www.fragstats.org/})
 and adds new ones from the current literature on landscape metrics. This package
 supports 'terra' SpatRaster objects as input arguments. It further provides
 utility functions to visualize patches, select metrics and building blocks to

--- a/man/list_lsm.Rd
+++ b/man/list_lsm.Rd
@@ -56,8 +56,7 @@ list_lsm(what = c("lsm_c_tca", "lsm_l_ta"))
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }

--- a/man/lsm_c_ai.Rd
+++ b/man/lsm_c_ai.Rd
@@ -36,10 +36,9 @@ lsm_c_ai(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 He, H. S., DeZonia, B. E., & Mladenoff, D. J. 2000. An aggregation index (AI)
 to quantify spatial patterns of landscapes. Landscape ecology, 15(7), 591-601.

--- a/man/lsm_c_area_cv.Rd
+++ b/man/lsm_c_area_cv.Rd
@@ -37,10 +37,9 @@ lsm_c_area_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}}, \cr

--- a/man/lsm_c_area_mn.Rd
+++ b/man/lsm_c_area_mn.Rd
@@ -38,10 +38,9 @@ lsm_c_area_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_c_area_sd.Rd
+++ b/man/lsm_c_area_sd.Rd
@@ -38,10 +38,9 @@ lsm_c_area_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_c_ca.Rd
+++ b/man/lsm_c_ca.Rd
@@ -41,10 +41,9 @@ lsm_c_ca(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_c_cai_cv.Rd
+++ b/man/lsm_c_cai_cv.Rd
@@ -53,10 +53,9 @@ lsm_c_cai_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}}, \cr

--- a/man/lsm_c_cai_mn.Rd
+++ b/man/lsm_c_cai_mn.Rd
@@ -50,10 +50,9 @@ lsm_c_cai_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}},

--- a/man/lsm_c_cai_sd.Rd
+++ b/man/lsm_c_cai_sd.Rd
@@ -52,10 +52,9 @@ lsm_c_cai_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}},

--- a/man/lsm_c_circle_cv.Rd
+++ b/man/lsm_c_circle_cv.Rd
@@ -41,10 +41,9 @@ lsm_c_circle_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_c_circle_mn.Rd
+++ b/man/lsm_c_circle_mn.Rd
@@ -39,10 +39,9 @@ lsm_c_circle_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_c_circle_sd.Rd
+++ b/man/lsm_c_circle_sd.Rd
@@ -39,10 +39,9 @@ lsm_c_circle_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_c_clumpy.Rd
+++ b/man/lsm_c_clumpy.Rd
@@ -40,8 +40,7 @@ lsm_c_clumpy(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }

--- a/man/lsm_c_cohesion.Rd
+++ b/man/lsm_c_cohesion.Rd
@@ -39,10 +39,9 @@ lsm_c_cohesion(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Schumaker, N. H. 1996. Using landscape indices to predict habitat
 connectivity. Ecology, 77(4), 1210-1225.

--- a/man/lsm_c_contig_cv.Rd
+++ b/man/lsm_c_contig_cv.Rd
@@ -48,10 +48,9 @@ lsm_c_contig_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_c_contig_mn.Rd
+++ b/man/lsm_c_contig_mn.Rd
@@ -47,10 +47,9 @@ lsm_c_contig_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_c_contig_sd.Rd
+++ b/man/lsm_c_contig_sd.Rd
@@ -48,10 +48,9 @@ lsm_c_contig_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_c_core_cv.Rd
+++ b/man/lsm_c_core_cv.Rd
@@ -49,10 +49,9 @@ lsm_c_core_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}}, \cr

--- a/man/lsm_c_core_mn.Rd
+++ b/man/lsm_c_core_mn.Rd
@@ -47,10 +47,9 @@ lsm_c_core_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_c_core_sd.Rd
+++ b/man/lsm_c_core_sd.Rd
@@ -48,10 +48,9 @@ lsm_c_core_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_c_cpland.Rd
+++ b/man/lsm_c_cpland.Rd
@@ -51,10 +51,9 @@ lsm_c_cpland(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}} and \code{\link{lsm_l_ta}}

--- a/man/lsm_c_dcad.Rd
+++ b/man/lsm_c_dcad.Rd
@@ -52,10 +52,9 @@ lsm_c_dcad(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_ndca}},

--- a/man/lsm_c_dcore_cv.Rd
+++ b/man/lsm_c_dcore_cv.Rd
@@ -52,10 +52,9 @@ lsm_c_dcore_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}}, \cr

--- a/man/lsm_c_dcore_mn.Rd
+++ b/man/lsm_c_dcore_mn.Rd
@@ -49,10 +49,9 @@ lsm_c_dcore_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}},

--- a/man/lsm_c_dcore_sd.Rd
+++ b/man/lsm_c_dcore_sd.Rd
@@ -52,10 +52,9 @@ lsm_c_dcore_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}},

--- a/man/lsm_c_division.Rd
+++ b/man/lsm_c_division.Rd
@@ -37,10 +37,9 @@ lsm_c_division(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_c_ed.Rd
+++ b/man/lsm_c_ed.Rd
@@ -43,10 +43,9 @@ lsm_c_ed(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_te}},

--- a/man/lsm_c_enn_cv.Rd
+++ b/man/lsm_c_enn_cv.Rd
@@ -42,10 +42,9 @@ lsm_c_enn_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_c_enn_mn.Rd
+++ b/man/lsm_c_enn_mn.Rd
@@ -42,10 +42,9 @@ lsm_c_enn_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_c_enn_sd.Rd
+++ b/man/lsm_c_enn_sd.Rd
@@ -42,10 +42,9 @@ lsm_c_enn_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_c_frac_cv.Rd
+++ b/man/lsm_c_frac_cv.Rd
@@ -40,10 +40,9 @@ lsm_c_frac_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_c_frac_mn.Rd
+++ b/man/lsm_c_frac_mn.Rd
@@ -36,10 +36,9 @@ lsm_c_frac_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_c_frac_sd.Rd
+++ b/man/lsm_c_frac_sd.Rd
@@ -39,10 +39,9 @@ lsm_c_frac_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_c_gyrate_cv.Rd
+++ b/man/lsm_c_gyrate_cv.Rd
@@ -48,10 +48,9 @@ lsm_c_gyrate_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_c_gyrate_mn.Rd
+++ b/man/lsm_c_gyrate_mn.Rd
@@ -46,10 +46,9 @@ lsm_c_gyrate_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_c_gyrate_sd.Rd
+++ b/man/lsm_c_gyrate_sd.Rd
@@ -47,10 +47,9 @@ lsm_c_gyrate_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_c_iji.Rd
+++ b/man/lsm_c_iji.Rd
@@ -37,10 +37,9 @@ landscape <- terra::rast(landscapemetrics::landscape)
 lsm_c_iji(landscape)
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., & Marks, B. J. 1995. FRAGSTATS: spatial pattern analysis
 program for quantifying landscape structure. Gen. Tech. Rep. PNW-GTR-351.

--- a/man/lsm_c_lpi.Rd
+++ b/man/lsm_c_lpi.Rd
@@ -38,10 +38,9 @@ lsm_c_lpi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_c_lsi.Rd
+++ b/man/lsm_c_lsi.Rd
@@ -36,10 +36,9 @@ lsm_c_lsi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_c_mesh.Rd
+++ b/man/lsm_c_mesh.Rd
@@ -39,10 +39,9 @@ lsm_c_mesh(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_c_ndca.Rd
+++ b/man/lsm_c_ndca.Rd
@@ -53,10 +53,9 @@ lsm_c_ndca(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_tca}}, \cr

--- a/man/lsm_c_nlsi.Rd
+++ b/man/lsm_c_nlsi.Rd
@@ -40,10 +40,9 @@ lsm_c_nlsi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_c_np.Rd
+++ b/man/lsm_c_np.Rd
@@ -36,10 +36,9 @@ lsm_c_np(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_l_np}}

--- a/man/lsm_c_pafrac.Rd
+++ b/man/lsm_c_pafrac.Rd
@@ -43,10 +43,9 @@ lsm_c_pafrac(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Burrough, P. A. 1986. Principles of Geographical Information Systems for
 Land Resources Assessment. Monographs on Soil and Resources Survey No. 12.

--- a/man/lsm_c_para_cv.Rd
+++ b/man/lsm_c_para_cv.Rd
@@ -40,10 +40,9 @@ lsm_c_para_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}}, \cr

--- a/man/lsm_c_para_mn.Rd
+++ b/man/lsm_c_para_mn.Rd
@@ -40,10 +40,9 @@ lsm_c_para_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}},

--- a/man/lsm_c_para_sd.Rd
+++ b/man/lsm_c_para_sd.Rd
@@ -40,10 +40,9 @@ lsm_c_para_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}},

--- a/man/lsm_c_pd.Rd
+++ b/man/lsm_c_pd.Rd
@@ -39,10 +39,9 @@ lsm_c_pd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_np}},

--- a/man/lsm_c_pladj.Rd
+++ b/man/lsm_c_pladj.Rd
@@ -36,8 +36,7 @@ lsm_c_pladj(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/.
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org.
 }

--- a/man/lsm_c_pland.Rd
+++ b/man/lsm_c_pland.Rd
@@ -38,10 +38,9 @@ lsm_c_pland(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_ca}},

--- a/man/lsm_c_shape_cv.Rd
+++ b/man/lsm_c_shape_cv.Rd
@@ -38,10 +38,9 @@ lsm_c_shape_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_c_shape_mn.Rd
+++ b/man/lsm_c_shape_mn.Rd
@@ -38,10 +38,9 @@ lsm_c_shape_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_c_shape_sd.Rd
+++ b/man/lsm_c_shape_sd.Rd
@@ -38,10 +38,9 @@ lsm_c_shape_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_c_split.Rd
+++ b/man/lsm_c_split.Rd
@@ -37,10 +37,9 @@ lsm_c_split(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_c_tca.Rd
+++ b/man/lsm_c_tca.Rd
@@ -48,10 +48,9 @@ lsm_c_tca(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_c_te.Rd
+++ b/man/lsm_c_te.Rd
@@ -40,10 +40,9 @@ lsm_c_te(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_perim}}

--- a/man/lsm_l_ai.Rd
+++ b/man/lsm_l_ai.Rd
@@ -38,10 +38,9 @@ lsm_l_ai(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 He, H. S., DeZonia, B. E., & Mladenoff, D. J. 2000. An aggregation index (AI)
 to quantify spatial patterns of landscapes. Landscape ecology, 15(7), 591-601.

--- a/man/lsm_l_area_cv.Rd
+++ b/man/lsm_l_area_cv.Rd
@@ -37,10 +37,9 @@ lsm_l_area_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}}, \cr

--- a/man/lsm_l_area_mn.Rd
+++ b/man/lsm_l_area_mn.Rd
@@ -38,10 +38,9 @@ lsm_l_area_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_l_area_sd.Rd
+++ b/man/lsm_l_area_sd.Rd
@@ -36,10 +36,9 @@ lsm_l_area_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_l_cai_cv.Rd
+++ b/man/lsm_l_cai_cv.Rd
@@ -53,10 +53,9 @@ lsm_l_cai_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}}, \cr

--- a/man/lsm_l_cai_mn.Rd
+++ b/man/lsm_l_cai_mn.Rd
@@ -50,10 +50,9 @@ lsm_l_cai_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}},

--- a/man/lsm_l_cai_sd.Rd
+++ b/man/lsm_l_cai_sd.Rd
@@ -52,10 +52,9 @@ lsm_l_cai_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_cai}},

--- a/man/lsm_l_circle_cv.Rd
+++ b/man/lsm_l_circle_cv.Rd
@@ -39,10 +39,9 @@ lsm_l_circle_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_l_circle_mn.Rd
+++ b/man/lsm_l_circle_mn.Rd
@@ -38,10 +38,9 @@ lsm_l_circle_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_l_circle_sd.Rd
+++ b/man/lsm_l_circle_sd.Rd
@@ -40,10 +40,9 @@ lsm_l_circle_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_l_cohesion.Rd
+++ b/man/lsm_l_cohesion.Rd
@@ -34,10 +34,9 @@ lsm_l_cohesion(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Schumaker, N. H. 1996. Using landscape indices to predict habitat
 connectivity. Ecology, 77(4), 1210-1225.

--- a/man/lsm_l_contag.Rd
+++ b/man/lsm_l_contag.Rd
@@ -44,10 +44,9 @@ lsm_l_contag(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Riitters, K.H., O’Neill, R.V., Wickham, J.D. & Jones, K.B. (1996). A note on
 contagion indices for landscape analysis. Landscape ecology, 11, 197–202.

--- a/man/lsm_l_contig_cv.Rd
+++ b/man/lsm_l_contig_cv.Rd
@@ -48,10 +48,9 @@ lsm_l_contig_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_l_contig_mn.Rd
+++ b/man/lsm_l_contig_mn.Rd
@@ -47,10 +47,9 @@ lsm_l_contig_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_l_contig_sd.Rd
+++ b/man/lsm_l_contig_sd.Rd
@@ -48,10 +48,9 @@ lsm_l_contig_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_l_core_cv.Rd
+++ b/man/lsm_l_core_cv.Rd
@@ -50,10 +50,9 @@ lsm_l_core_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}}, \cr

--- a/man/lsm_l_core_mn.Rd
+++ b/man/lsm_l_core_mn.Rd
@@ -48,10 +48,9 @@ lsm_l_core_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_l_core_sd.Rd
+++ b/man/lsm_l_core_sd.Rd
@@ -49,10 +49,9 @@ lsm_l_core_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_l_dcad.Rd
+++ b/man/lsm_l_dcad.Rd
@@ -52,10 +52,9 @@ lsm_l_dcad(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_ndca}},

--- a/man/lsm_l_dcore_cv.Rd
+++ b/man/lsm_l_dcore_cv.Rd
@@ -52,10 +52,9 @@ lsm_l_dcore_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}}, \cr

--- a/man/lsm_l_dcore_mn.Rd
+++ b/man/lsm_l_dcore_mn.Rd
@@ -49,10 +49,9 @@ lsm_l_dcore_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}},

--- a/man/lsm_l_dcore_sd.Rd
+++ b/man/lsm_l_dcore_sd.Rd
@@ -51,10 +51,9 @@ lsm_l_dcore_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_ncore}},

--- a/man/lsm_l_division.Rd
+++ b/man/lsm_l_division.Rd
@@ -37,10 +37,9 @@ lsm_l_division(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_l_ed.Rd
+++ b/man/lsm_l_ed.Rd
@@ -43,10 +43,9 @@ lsm_l_ed(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_l_te}},

--- a/man/lsm_l_enn_cv.Rd
+++ b/man/lsm_l_enn_cv.Rd
@@ -42,10 +42,9 @@ lsm_l_enn_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_l_enn_mn.Rd
+++ b/man/lsm_l_enn_mn.Rd
@@ -42,10 +42,9 @@ lsm_l_enn_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_l_enn_sd.Rd
+++ b/man/lsm_l_enn_sd.Rd
@@ -42,10 +42,9 @@ lsm_l_enn_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_l_frac_cv.Rd
+++ b/man/lsm_l_frac_cv.Rd
@@ -40,10 +40,9 @@ lsm_l_frac_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_l_frac_mn.Rd
+++ b/man/lsm_l_frac_mn.Rd
@@ -39,10 +39,9 @@ lsm_l_frac_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_l_frac_sd.Rd
+++ b/man/lsm_l_frac_sd.Rd
@@ -39,10 +39,9 @@ lsm_l_frac_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_l_gyrate_cv.Rd
+++ b/man/lsm_l_gyrate_cv.Rd
@@ -48,10 +48,9 @@ lsm_l_gyrate_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_l_gyrate_mn.Rd
+++ b/man/lsm_l_gyrate_mn.Rd
@@ -46,10 +46,9 @@ lsm_l_gyrate_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_l_gyrate_sd.Rd
+++ b/man/lsm_l_gyrate_sd.Rd
@@ -47,10 +47,9 @@ lsm_l_gyrate_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_l_iji.Rd
+++ b/man/lsm_l_iji.Rd
@@ -38,10 +38,9 @@ landscape <- terra::rast(landscapemetrics::landscape)
 lsm_l_iji(landscape)
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., & Marks, B. J. 1995. FRAGSTATS: spatial pattern analysis
 program for quantifying landscape structure. Gen. Tech. Rep. PNW-GTR-351.

--- a/man/lsm_l_lpi.Rd
+++ b/man/lsm_l_lpi.Rd
@@ -38,10 +38,9 @@ lsm_l_lpi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_l_lsi.Rd
+++ b/man/lsm_l_lsi.Rd
@@ -36,10 +36,9 @@ lsm_l_lsi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_l_mesh.Rd
+++ b/man/lsm_l_mesh.Rd
@@ -39,10 +39,9 @@ lsm_l_mesh(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_l_msidi.Rd
+++ b/man/lsm_l_msidi.Rd
@@ -35,10 +35,9 @@ lsm_l_msidi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 

--- a/man/lsm_l_msiei.Rd
+++ b/man/lsm_l_msiei.Rd
@@ -33,10 +33,9 @@ lsm_l_msiei(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 

--- a/man/lsm_l_ndca.Rd
+++ b/man/lsm_l_ndca.Rd
@@ -53,10 +53,9 @@ lsm_l_ndca(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_tca}}, \cr

--- a/man/lsm_l_np.Rd
+++ b/man/lsm_l_np.Rd
@@ -37,10 +37,9 @@ lsm_l_np(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_np}}

--- a/man/lsm_l_pafrac.Rd
+++ b/man/lsm_l_pafrac.Rd
@@ -43,10 +43,9 @@ lsm_l_pafrac(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Burrough, P. A. 1986. Principles of Geographical Information Systems for
 Land Resources Assessment. Monographs on Soil and Resources Survey No. 12.

--- a/man/lsm_l_para_cv.Rd
+++ b/man/lsm_l_para_cv.Rd
@@ -40,10 +40,9 @@ lsm_l_para_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}}, \cr

--- a/man/lsm_l_para_mn.Rd
+++ b/man/lsm_l_para_mn.Rd
@@ -40,10 +40,9 @@ lsm_l_para_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}},

--- a/man/lsm_l_para_sd.Rd
+++ b/man/lsm_l_para_sd.Rd
@@ -40,10 +40,9 @@ lsm_l_para_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_para}},

--- a/man/lsm_l_pd.Rd
+++ b/man/lsm_l_pd.Rd
@@ -39,10 +39,9 @@ lsm_l_pd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_np}},

--- a/man/lsm_l_pladj.Rd
+++ b/man/lsm_l_pladj.Rd
@@ -36,8 +36,7 @@ lsm_l_pladj(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/.
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org.
 }

--- a/man/lsm_l_pr.Rd
+++ b/man/lsm_l_pr.Rd
@@ -34,8 +34,7 @@ lsm_l_pr(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }

--- a/man/lsm_l_prd.Rd
+++ b/man/lsm_l_prd.Rd
@@ -39,8 +39,7 @@ lsm_l_prd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }

--- a/man/lsm_l_rpr.Rd
+++ b/man/lsm_l_rpr.Rd
@@ -40,10 +40,9 @@ lsm_l_rpr(landscape, classes_max = 5)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Romme, W. H. 1982. Fire and landscapediversity in subalpine forests of
 Yellowstone National Park.Ecol.Monogr. 52:199-221

--- a/man/lsm_l_shape_cv.Rd
+++ b/man/lsm_l_shape_cv.Rd
@@ -38,10 +38,9 @@ lsm_l_shape_cv(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_l_shape_mn.Rd
+++ b/man/lsm_l_shape_mn.Rd
@@ -38,10 +38,9 @@ lsm_l_shape_mn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_l_shape_sd.Rd
+++ b/man/lsm_l_shape_sd.Rd
@@ -38,10 +38,9 @@ lsm_l_shape_sd(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/lsm_l_shdi.Rd
+++ b/man/lsm_l_shdi.Rd
@@ -34,10 +34,9 @@ lsm_l_shdi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Shannon, C., and W. Weaver. 1949. The mathematical theory of
 communication. Univ. IllinoisPress, Urbana

--- a/man/lsm_l_shei.Rd
+++ b/man/lsm_l_shei.Rd
@@ -35,10 +35,9 @@ lsm_l_shei(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Shannon, C., and W. Weaver. 1949. The mathematical theory of
 communication. Univ. IllinoisPress, Urbana

--- a/man/lsm_l_sidi.Rd
+++ b/man/lsm_l_sidi.Rd
@@ -39,10 +39,9 @@ lsm_l_sidi(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 }

--- a/man/lsm_l_siei.Rd
+++ b/man/lsm_l_siei.Rd
@@ -39,10 +39,9 @@ lsm_l_siei(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Simpson, E. H. 1949. Measurement of diversity. Nature 163:688
 }

--- a/man/lsm_l_split.Rd
+++ b/man/lsm_l_split.Rd
@@ -37,10 +37,9 @@ lsm_l_split(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Jaeger, J. A. 2000. Landscape division, splitting index, and effective mesh
 size: new measures of landscape fragmentation.

--- a/man/lsm_l_ta.Rd
+++ b/man/lsm_l_ta.Rd
@@ -36,10 +36,9 @@ lsm_l_ta(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_l_tca.Rd
+++ b/man/lsm_l_tca.Rd
@@ -47,10 +47,9 @@ lsm_l_tca(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_l_te.Rd
+++ b/man/lsm_l_te.Rd
@@ -37,10 +37,9 @@ lsm_l_te(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_perim}}

--- a/man/lsm_p_area.Rd
+++ b/man/lsm_p_area.Rd
@@ -38,10 +38,9 @@ lsm_p_area(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_area_mn}},

--- a/man/lsm_p_cai.Rd
+++ b/man/lsm_p_cai.Rd
@@ -46,10 +46,9 @@ lsm_p_cai(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_core}},

--- a/man/lsm_p_circle.Rd
+++ b/man/lsm_p_circle.Rd
@@ -40,10 +40,9 @@ lsm_p_circle(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Baker, W. L., and Y. Cai. 1992. The r.le programs for multiscale analysis of
 landscape structure using the GRASS geographical information system.

--- a/man/lsm_p_contig.Rd
+++ b/man/lsm_p_contig.Rd
@@ -49,10 +49,9 @@ lsm_p_contig(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 LaGro, J. 1991. Assessing patch shape in landscape mosaics.
 Photogrammetric Engineering and Remote Sensing, 57(3), 285-293

--- a/man/lsm_p_core.Rd
+++ b/man/lsm_p_core.Rd
@@ -51,10 +51,9 @@ lsm_p_core(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_core_mn}},

--- a/man/lsm_p_enn.Rd
+++ b/man/lsm_p_enn.Rd
@@ -43,10 +43,9 @@ lsm_p_enn(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 McGarigal, K., and McComb, W. C. (1995). Relationships between landscape
 structure and breeding birds in the Oregon Coast Range.

--- a/man/lsm_p_frac.Rd
+++ b/man/lsm_p_frac.Rd
@@ -39,10 +39,9 @@ lsm_p_frac(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Mandelbrot, B. B. 1977. Fractals: Form, Chance, and Dimension.
 San Francisco. W. H. Freeman and Company.

--- a/man/lsm_p_gyrate.Rd
+++ b/man/lsm_p_gyrate.Rd
@@ -45,10 +45,9 @@ lsm_p_gyrate(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Keitt, T. H., Urban, D. L., & Milne, B. T. 1997. Detecting critical scales
 in fragmented landscapes. Conservation ecology, 1(1).

--- a/man/lsm_p_ncore.Rd
+++ b/man/lsm_p_ncore.Rd
@@ -52,10 +52,9 @@ lsm_p_ncore(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_c_dcore_mn}},

--- a/man/lsm_p_para.Rd
+++ b/man/lsm_p_para.Rd
@@ -39,10 +39,9 @@ lsm_p_para(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{lsm_p_area}},

--- a/man/lsm_p_perim.Rd
+++ b/man/lsm_p_perim.Rd
@@ -38,8 +38,7 @@ lsm_p_perim(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }

--- a/man/lsm_p_shape.Rd
+++ b/man/lsm_p_shape.Rd
@@ -38,10 +38,9 @@ lsm_p_shape(landscape)
 
 }
 \references{
-McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-web site: https://www.umass.edu/landeco/
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 
 Patton, D. R. 1975. A diversity index for quantifying habitat "edge".
 Wildl. Soc.Bull. 3:171-173.

--- a/man/window_lsm.Rd
+++ b/man/window_lsm.Rd
@@ -71,10 +71,9 @@ Hagen-Zanker, A. (2016). A computational framework for generalized moving window
 and its application to landscape pattern analysis. International journal of applied
 earth observation and geoinformation, 44, 205-216.
 
-McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis
-Program for Categorical and Continuous Maps. Computer software program produced by
-the authors at the University of Massachusetts, Amherst. Available at the following
-website: \url{https://www.umass.edu/landeco/}
+McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis
+Program for Categorical Maps. Computer software program produced by the authors;
+available at the following web site: https://www.fragstats.org
 }
 \seealso{
 \code{\link{list_lsm}} \cr

--- a/vignettes/articles/comparing_tools.Rmd
+++ b/vignettes/articles/comparing_tools.Rmd
@@ -29,7 +29,7 @@ landscape <- terra::rast(landscapemetrics::landscape)
 
 # Comparison with FRAGSTATS
 
-**landscapemetrics** re-implements landscape metrics as they are mostly described in the FRAGSTATS software (McGarigal *et al.* 2012). 
+**landscapemetrics** re-implements landscape metrics as they are mostly described in the FRAGSTATS software (McGarigal *et al.* 2023). 
 Therefore, we compared our results with the results of FRAGSTATS.
 In the process, we recognized a few differences between the results. 
 
@@ -378,6 +378,6 @@ knitr::kable(bind_rows(sdmtools_result))
 
 ## References 
 
-- McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following website: https://www.umass.edu/landeco/
+- McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: https://www.fragstats.org
 - Jeremy VanDerWal, Lorena Falconi, Stephanie Januchowski, Luke Shoo and Collin Storlie (2014). SDMTools: Species Distribution Modelling Tools: Tools for processing data associated with species distribution modelling exercises. R package version 1.1-221. https://CRAN.R-project.org/package=SDMTools
 

--- a/vignettes/articles/general_background.Rmd
+++ b/vignettes/articles/general_background.Rmd
@@ -86,10 +86,10 @@ For more information, please see [New Metrics outside FRAGSTATS](https://r-spati
 
 ## Other software to calculate landscape metrics
 
-There are already software packages available to calculate landscape metrics, the most famous one probably being the stand-alone software FRAGSTATS (McGarigal *et al.* 2012). But also add-ons to GIS software are available, e.g. r.le (Baker & Cai 1992) or its successor r.li for GRASS GIS. 
+There are already software packages available to calculate landscape metrics, the most famous one probably being the stand-alone software FRAGSTATS (McGarigal *et al.* 2023). But also add-ons to GIS software are available, e.g. r.le (Baker & Cai 1992) or its successor r.li for GRASS GIS. 
 Lastly, also an R package, namely `SDMTools` (VanDerWal *et al.* 2014), can be used.
 
-Nevertheless, we decided to re-implement most of the metrics available in [FRAGSTATS](https://www.umass.edu/landeco/research/fragstats/documents/fragstats_documents.html).
+Nevertheless, we decided to re-implement most of the metrics available in [FRAGSTATS](https://www.fragstats.org/index.php/documentation).
 We wanted to provide a comprehensive collection of landscape metrics in R.
 While FRAGSTATS is an extensive collection it is only available for Windows.
 Note, that even though we tried to re-implement the metrics as described in the FRAGSTATS manual, there are some differences ([Differences FRAGSTATS|landscapemetrics](https://r-spatialecology.github.io/landscapemetrics/articles/articles/comparing_fragstats_landscapemetrics.html)). 
@@ -102,5 +102,5 @@ Those were the main reasons we implemented **landscapemetrics**, however, we wan
 ### References 
 
 - Baker, W.L. and Cai, Y. 1992. The r.le programs for multiscale analysis of landscape structure using the GRASS geographical information system. Landscape Ecology 7(4):291-302.
-- McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following website: <https://www.umass.edu/landeco/>
+- McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: <https://www.fragstats.org>
 - VanDerWal, J., Falconi, L., Januchowski, S., Shoo, L., and Storlie, C. 2014. SDMTools: Species Distribution Modelling Tools: Tools for processing data associated with species distribution modelling exercises. R package version 1.1-221. <https://CRAN.R-project.org/package=SDMTools>

--- a/vignettes/articles/guide_moving_window.Rmd
+++ b/vignettes/articles/guide_moving_window.Rmd
@@ -79,5 +79,5 @@ In the future, we also plan to allow class level metrics, however, patch metrics
 
 - Fletcher, R., Fortin, M.-J. 2018. Spatial Ecology and Conservation Modeling: Applications with R. Springer International Publishing. 523 pages
 - Hagen-Zanker, A. 2016. A computational framework for generalized moving windows and its application to landscape pattern analysis. International journal of applied earth observation and geoinformation, 44, 205-216.
-- McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following website: <https://www.umass.edu/landeco/>
+- McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: <https://www.fragstats.org>
 - Šímová, P., & Gdulová, K. 2012. Landscape indices behavior: A review of scale effects. Applied Geography, 34, 385–394.

--- a/vignettes/articles/landscape_distribution_statistics.Rmd
+++ b/vignettes/articles/landscape_distribution_statistics.Rmd
@@ -100,4 +100,4 @@ metric_md_l
 
 ### References 
 
-- McGarigal, K., Cushman, S.A., and Ene E. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following website: <https://www.umass.edu/landeco/>
+- McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: <https://www.fragstats.org>


### PR DESCRIPTION
Hello,
since the **Fragstats** (https://www.fragstats.org) is back under development, and the links to https://www.umass.edu/landeco/ are abanduned, I updated the documentation - functions, vignettes, readmes and `codemeta.json`.  **This includes the intext references** in vignettes: McGarigal *et al.* 2012 -> McGarigal *et al.* 2023 (here I am not sure if this is desirable for you). Hope this will be helpful.

The reference changed:

from
> McGarigal, K., SA Cushman, and E Ene. 2012. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical and Continuous Maps. Computer software program produced by the authors at the University of Massachusetts, Amherst. Available at the following web site: https://www.umass.edu/landeco/

to

> McGarigal K., SA Cushman, and E Ene. 2023. FRAGSTATS v4: Spatial Pattern Analysis Program for Categorical Maps. Computer software program produced by the authors; available at the following web site: https://www.fragstats.org