### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -253,7 +253,7 @@
 
 # landscapemetrics 0.3.1
 * Bugfixes
-    * fixing bug in `sample_lsm()` that occured when metrics where selected using `what` argument
+    * fixing bug in `sample_lsm()` that occurred when metrics where selected using `what` argument
     * Bugfix in `lsm_p_core()` if only one patch is present
     * Bugfix in `lsm_p_circle()` if only one cell is present in class
     * Bugfix in `lsm_p_hyrate()` if only one cell is present in class
@@ -305,7 +305,7 @@
 * The `edge_depth` can be specified for all core metrics
 
 # landscapemetrics 0.1.1
-* Replaced isFALSE() with !isTRUE() to be compatibile to R (> 3.1)
+* Replaced isFALSE() with !isTRUE() to be compatible to R (> 3.1)
 * Bugfix: lsm_p_core() and lsm_p_ncore() now takes landscape boundary into account
 * Added namespace prefix std::fmod() in get_adjacency.cpp
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ There are several ways to install **landscapemetrics**:
 # Get the stable version from CRAN
 install.packages("landscapemetrics")
 
-# Alternatively, you can install the development version from Github
+# Alternatively, you can install the development version from GitHub
 # install.packages("remotes")
 remotes::install_github("r-spatialecology/landscapemetrics")
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are several ways to install **landscapemetrics**:
 # Get the stable version from CRAN
 install.packages("landscapemetrics")
 
-# Alternatively, you can install the development version from Github
+# Alternatively, you can install the development version from GitHub
 # install.packages("remotes")
 remotes::install_github("r-spatialecology/landscapemetrics")
 ```


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues in project documentation files.

**Details:** Fix documentation typos: occured->occurred (x1); compatibile->compatible (x1); Github->GitHub (x2)

**Files:**
- `NEWS.md`
- `README.md`
- `README.Rmd`

Documentation-only change; no functional code updates.
